### PR TITLE
Align Android module with Flutter 3.24 Java 17 requirements

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,7 +15,6 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "app.biedronka.biedronka_expenses"
     compileSdk = 34
-    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -23,7 +22,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+        jvmTarget = "17"
     }
 
     signingConfigs {


### PR DESCRIPTION
## Summary
- remove the unused ndkVersion reference from the Android application module to avoid NDK dependency
- set the Kotlin JVM target to 17 to match Flutter 3.24.x Java requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a8397204832f9722e82eaa8306c9