### PR TITLE
Fix Flutter plugin loader configuration

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,14 +1,4 @@
 pluginManagement {
-    def flutterSdkPath = {
-        def properties = new Properties()
-        file("local.properties").withInputStream { properties.load(it) }
-        def flutterSdkPath = properties.getProperty("flutter.sdk")
-        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-        return flutterSdkPath
-    }()
-
-    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
-
     repositories {
         google()
         mavenCentral()
@@ -17,9 +7,25 @@ pluginManagement {
 }
 
 plugins {
-    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
     id "org.jetbrains.kotlin.android" version "1.9.25" apply false
 }
 
 include ":app"
+
+def localPropertiesFile = rootProject.file("local.properties")
+def properties = new Properties()
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withInputStream { properties.load(it) }
+}
+
+def flutterSdkPath = properties.getProperty("flutter.sdk")
+if (flutterSdkPath == null) {
+    flutterSdkPath = System.getenv("FLUTTER_SDK")
+}
+if (flutterSdkPath == null) {
+    throw new GradleException("Flutter SDK not found. Define flutter.sdk in android/local.properties or set the FLUTTER_SDK environment variable.")
+}
+
+setBinding(new Binding([gradle: this]))
+evaluate(new File(flutterSdkPath, "packages/flutter_tools/gradle/app_plugin_loader.gradle"))


### PR DESCRIPTION
## Summary
- load Flutter's app plugin loader explicitly so Gradle picks up Android plugin subprojects
- allow resolving the Flutter SDK from either local.properties or the FLUTTER_SDK environment variable to avoid stale paths

## Testing
- flutter test *(fails: Because every version of flutter_test from sdk depends on path 1.9.0 and project depends on path ^1.9.1)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bdd81e04832f9860c5f6c546cd06