### PR TITLE
Handle modern Biedronka receipt format

### DIFF
--- a/assets/sample_receipt_modern.txt
+++ b/assets/sample_receipt_modern.txt
@@ -1,0 +1,23 @@
+Sklep 4553 H.GORDONOWNY 12
+Jeronimo Martins Polska S.A.
+ul. Żniwna 5, 62-005 Kostrzyn
+NIP 779-10-11-327
+
+06.09.2025 14:33
+
+NIEFISKALNY
+
+Nazwa                PTU Ilość Cena Wartość
+Mleko SPOŻ 2%        A   1,000 x 5,28 5,28
+Ser żółty plastry     B   0,300 kg x 32,99 9,90
+Makaron pełnoziarn.  C   2,000 x 4,79 9,58
+Rabat kupon lojaln.      -1,50 PLN
+
+Suma PLN 23,26
+Gotówka 30,00 PLN
+Reszta 6,74 PLN
+
+VAT A 5%    podstawa    5,03  VAT  0,25
+VAT B 8%    podstawa    9,17  VAT  0,73
+VAT C 23%   podstawa   7,89  VAT  1,81
+Suma VAT 2,79

--- a/test/receipt_parser_new_format_test.dart
+++ b/test/receipt_parser_new_format_test.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:biedronka_expenses/domain/parsing/receipt_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('parses modern Biedronka receipt layout', () async {
+    final parser = ReceiptParser();
+    final text = await File('assets/sample_receipt_modern.txt').readAsString();
+
+    final receipt = parser.parse(text);
+
+    expect(receipt.merchantId, 'biedronka');
+    expect(receipt.purchaseTimestamp, DateTime(2025, 9, 6, 14, 33));
+    expect(receipt.totalGross, closeTo(23.26, 0.01));
+    expect(receipt.items.length, 4);
+
+    final milk =
+        receipt.items.firstWhere((item) => item.name.startsWith('Mleko'));
+    expect(milk.quantity, closeTo(1, 0.001));
+    expect(milk.unit, 'szt');
+    expect(milk.unitPrice, closeTo(5.28, 0.01));
+
+    final cheese = receipt.items
+        .firstWhere((item) => item.name.startsWith('Ser żółty'));
+    expect(cheese.unit, 'kg');
+    expect(cheese.quantity, closeTo(0.3, 0.001));
+    expect(cheese.total, closeTo(9.90, 0.01));
+
+    final discount = receipt.items
+        .firstWhere((item) => item.name.toLowerCase().contains('rabat'));
+    expect(discount.total, closeTo(-1.50, 0.01));
+  });
+}


### PR DESCRIPTION
## Summary
- support single-line item rows and skip header text when parsing PDF receipts
- expand Biedronka receipt detection and normalize parsed units
- add a modern receipt fixture with a regression test for the new format

## Testing
- flutter test *(fails: dependency conflict with collection 1.19.1 vs flutter_test 1.19.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3e1c8958832f805cac82af19ed69