### PR TITLE
Update Android application ID to app.receipts_b

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The app includes Android-specific PDF text extraction using PdfBox-Android:
 ## Build Configuration
 
 The app is configured for:
-- **Package Name**: `app.biedronka.biedronka_expenses`
+- **Package Name**: `app.receipts_b`
 - **Kotlin**: 1.9+ with JDK 17
 - **Material 3**: Full Material You theming
 - **Offline-First**: No network dependencies in core functionality

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,7 +13,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace = "app.biedronka.biedronka_expenses"
+    namespace = "app.receipts_b"
     compileSdk = 34
 
     compileOptions {
@@ -35,7 +35,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "app.biedronka.biedronka_expenses"
+        applicationId = "app.receipts_b"
         minSdk = 24
         targetSdk = 34
         versionCode = flutter.versionCode

--- a/android/app/src/main/kotlin/app/receipts_b/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/receipts_b/MainActivity.kt
@@ -1,4 +1,4 @@
-package app.biedronka.biedronka_expenses
+package app.receipts_b
 
 import android.content.Context
 import android.net.Uri


### PR DESCRIPTION
## Summary
- update the Android namespace and applicationId to `app.receipts_b`
- move the `MainActivity` Kotlin file under the new package name
- refresh the README to document the new application ID

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de30c25a9c832fa8c3e39017891cc6