### PR TITLE
Handle optional JP2 AAR download

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,34 +10,45 @@ def jp2Ver = "1.0.3"
 def jp2Aar = "jp2-android-${jp2Ver}.aar"
 
 // URL and checksum can come from CI secrets; fall back to placeholders for local dev.
-def jp2Url = System.getenv("JP2_AAR_URL") ?: "<PUT_DIRECT_DOWNLOAD_URL_HERE>"
-def jp2Sha256 = System.getenv("JP2_AAR_SHA256") ?: "<PUT_SHA256_HERE>"
+def jp2PlaceholderUrl = "<PUT_DIRECT_DOWNLOAD_URL_HERE>"
+def jp2PlaceholderSha = "<PUT_SHA256_HERE>"
+def jp2Url = System.getenv("JP2_AAR_URL") ?: jp2PlaceholderUrl
+def jp2Sha256 = System.getenv("JP2_AAR_SHA256") ?: jp2PlaceholderSha
+
+def jp2LibsDir = file("$projectDir/libs")
+def jp2Lib = file("$projectDir/libs/$jp2Aar")
+def jp2SecretsProvided = jp2Url && jp2Url != jp2PlaceholderUrl && jp2Sha256 && jp2Sha256 != jp2PlaceholderSha
+def jp2AvailableLocally = jp2Lib.exists()
+def includeJp2 = jp2SecretsProvided || jp2AvailableLocally
 
 tasks.register("fetchJp2Aar") {
-    outputs.file("$projectDir/libs/$jp2Aar")
+    outputs.file(jp2Lib)
+    onlyIf { jp2SecretsProvided && !jp2AvailableLocally }
     doLast {
-        def destDir = file("$projectDir/libs")
-        def dest = file("$projectDir/libs/$jp2Aar")
-        if (!dest.exists()) {
-            destDir.mkdirs()
-            new URL(jp2Url).withInputStream { i -> dest.withOutputStream { it << i } }
+        if (!jp2Lib.exists()) {
+            jp2LibsDir.mkdirs()
+            new URL(jp2Url).withInputStream { i -> jp2Lib.withOutputStream { it << i } }
 
             // Verify SHA-256
             def md = java.security.MessageDigest.getInstance("SHA-256")
-            dest.withInputStream { is ->
+            jp2Lib.withInputStream { is ->
                 byte[] buf = new byte[8192]; int r
                 while ((r = is.read(buf)) > 0) md.update(buf, 0, r)
             }
             def actual = md.digest().encodeHex().toString()
             if (actual != jp2Sha256) {
-                dest.delete()
+                jp2Lib.delete()
                 throw new GradleException("Checksum mismatch for $jp2Aar: $actual")
             }
         }
     }
 }
 
-preBuild.dependsOn("fetchJp2Aar")
+if (includeJp2) {
+    preBuild.dependsOn("fetchJp2Aar")
+} else {
+    logger.lifecycle("JP2 AAR not configured and libs/$jp2Aar missing; continuing without optional JPEG2000 support.")
+}
 
 
 def keystoreProperties = new Properties()
@@ -87,7 +98,11 @@ android {
 
 dependencies {
     implementation 'com.tom-roush:pdfbox-android:2.0.27.0'
-    implementation files("libs/$jp2Aar")
+    if (includeJp2) {
+        implementation files("libs/$jp2Aar")
+    } else {
+        logger.lifecycle("JP2 AAR dependency disabled; build will proceed without JPEG2000 decoding support.")
+    }
 }
 
 flutter {


### PR DESCRIPTION
## Summary
- guard the JP2 download task against placeholder values so CI skips the fetch when secrets are absent
- conditionally wire the JP2 pre-build dependency and implementation entry only when the AAR is available

## Testing
- flutter build apk --debug *(fails: Flutter SDK version 0.0.0-unknown while >=3.24.0 is required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de667e4804832fb8d1ad27d687d84b