### PR TITLE
Ensure Kotlin language level 1.9 for Android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,8 @@ subprojects {
             project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
                 kotlinOptions {
                     jvmTarget = "17"
+                    languageVersion = "1.9"
+                    apiVersion = "1.9"
                 }
             }
         }


### PR DESCRIPTION
## Summary
- configure every Kotlin compilation task to use language and API version 1.9 alongside JVM target 17

## Testing
- flutter build apk --debug *(fails: Flutter SDK 0.0.0-unknown in container, requires >=3.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f6559a8c832fb1cda5116ce22a7f