### PR TITLE
Improve Biedronka receipt detection

### DIFF
--- a/lib/domain/parsing/receipt_parser.dart
+++ b/lib/domain/parsing/receipt_parser.dart
@@ -247,10 +247,20 @@ class ReceiptParser {
 
   bool _isBiedronkaReceipt(String text) {
     final lower = text.toLowerCase();
+    final collapsed = lower.replaceAll(RegExp(r'[\s-]'), '');
+
+    bool containsJeronimoChain() {
+      return RegExp(r'jeronimo\s+martins\s+polska', caseSensitive: false)
+              .hasMatch(text) ||
+          collapsed.contains('jeronimomartinspolska');
+    }
+
     return lower.contains('biedronka') ||
-        lower.contains('jeronimo martins polska') ||
-        lower.contains('5261040567') ||
-        lower.contains('paragon fiskalny');
+        containsJeronimoChain() ||
+        collapsed.contains('5261040567') ||
+        collapsed.contains('7791011327') ||
+        lower.contains('paragon fiskalny') ||
+        lower.contains('niefiskalny');
   }
 
   String _categorize(String name) {

--- a/test/receipt_parser_new_format_test.dart
+++ b/test/receipt_parser_new_format_test.dart
@@ -31,4 +31,18 @@ void main() {
         .firstWhere((item) => item.name.toLowerCase().contains('rabat'));
     expect(discount.total, closeTo(-1.50, 0.01));
   });
+
+  test('detects Jeronimo header even when broken across lines', () async {
+    final parser = ReceiptParser();
+    final original = await File('assets/sample_receipt_modern.txt').readAsString();
+    final modified = original.replaceFirst(
+      'Jeronimo Martins Polska S.A.',
+      'Jeronimo\nMartins\nPolska S.A.',
+    );
+
+    final receipt = parser.parse(modified);
+
+    expect(receipt.merchantId, 'biedronka');
+    expect(receipt.items, isNotEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
- broaden the receipt source detection heuristics to catch Biedronka headers with extra whitespace and additional NIP variants
- add a regression test ensuring multi-line Jeronimo header text is still parsed successfully

## Testing
- flutter test test/receipt_parser_new_format_test.dart *(fails: Flutter SDK 0.0.0-unknown < required 3.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e53b1e1268832fa0ffa29982304524