### PR TITLE
Fix dependency resolution and integration cache path

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Cache pub packages
         uses: actions/cache@v4
         with:
-          path: ${{ env.FLUTTER_HOME }}/.pub-cache
+          path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-pub-

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: 2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   cross_file:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   workmanager: ^0.6.0
   sentry_flutter: ^8.12.0
   intl: ^0.20.1
-  collection: 1.19.0
+  collection: ^1.19.1
   crypto: ^3.0.6
   shared_preferences: ^2.3.2
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- align the collection package constraint with the Flutter SDK expectation
- refresh the lockfile entry for collection to version 1.19.1
- correct the integration workflow cache location so the pub cache is restored properly

## Testing
- not run (Flutter SDK upgrade unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e64c5242f0832f8bf93008772e8d60