### PR TITLE
Fix integration test workflow emulator configuration

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -48,7 +48,7 @@ jobs:
           force-avd-creation: true
           ram-size: 3072M
           cores: 2
-          emulator-wait-timeout: 900
+          emulator-boot-timeout: 900
           emulator-options: >-
             -no-snapshot -no-window -gpu swiftshader_indirect -noaudio
             -no-boot-anim -camera-back none -camera-front none


### PR DESCRIPTION
## Summary
- replace the deprecated `emulator-wait-timeout` input with the supported `emulator-boot-timeout` option in the Android integration test workflow so the action no longer fails during setup

## Testing
- not run (CI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e6aa2868f4832fb7fdf245ce31cb65