### PR TITLE
Disable automatic Android integration workflow and stabilize emulator startup

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,12 +1,7 @@
 name: Android Integration Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   integration-test:
@@ -53,7 +48,15 @@ jobs:
           emulator-boot-timeout: 900
           emulator-options: >-
             -no-snapshot -no-window -gpu swiftshader_indirect -noaudio
-            -no-boot-anim -camera-back none -camera-front none
+            -no-boot-anim -camera-back none -camera-front none -accel off
           disable-animations: true
+          disable-linux-hw-accel: true
           script: |
+            adb kill-server
+            adb start-server
+            adb wait-for-device
+            until adb shell getprop sys.boot_completed | grep -m 1 '1'; do
+              sleep 5
+            done
+            adb shell input keyevent 82
             timeout --preserve-status 10m flutter test integration_test -d emulator-5554


### PR DESCRIPTION
## Summary
- restrict the Android integration test workflow to manual dispatches only
- tweak emulator configuration to disable Linux hardware acceleration and wait for a fully booted device before running tests

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e8c8f607e0832f836bdffe0333a0d5