### PR TITLE
Add bilingual legal documentation

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,76 @@
+# Privacy Policy — Receipts
+_Effective date:_ 2025-10-12  
+_Controller:_ Varkan  
+_Contact:_ https://github.com/shatokh/Receipts/issues
+
+> **Summary (EN):**
+> - The app processes receipts/PDF content **on your device**. No cloud sync by default.
+> - We do **not** sell personal data.
+> - Optional diagnostics/crash reports may be sent **only if enabled** in the app/build.
+> - No in-app purchases or subscriptions at this time.
+
+> **Кратко (RU):**
+> - Приложение обрабатывает данные чеков/PDF **на вашем устройстве**. Облака по умолчанию нет.
+> - Мы **не продаём** персональные данные.
+> - Опциональная диагностика/крэши отправляются **только если включены** в приложении/сборке.
+> - В настоящий момент в приложении нет покупок или подписок.
+
+## 1. Scope / Область действия
+This Policy explains what data the app “Receipts” processes, why, and how you can exercise your rights.  
+Данная Политика описывает, какие данные обрабатывает приложение «Receipts», зачем и как вы можете реализовать свои права.
+
+## 2. Data We Process / Обрабатываемые данные
+**On-device data (EN):**
+- Receipts, PDFs, and metadata you open/import in the app.
+- App settings and preferences (stored locally).
+
+**Данные на устройстве (RU):**
+- Чеки, PDF и метаданные, которые вы открываете/импортируете в приложении.
+- Настройки приложения (локально).
+
+**Optional diagnostics (EN, if enabled):**
+- Crash reports and basic device info (OS, app version, stack traces).  
+- No precise location or contact list is collected by default.
+
+**Опциональная диагностика (RU, если включено):**
+- Отчёты о сбоях и базовая информация об устройстве (ОС, версия приложения, стектрейсы).  
+- Точная геолокация и контакты по умолчанию **не** собираются.
+
+## 3. Processing Purposes & Legal Bases (GDPR) / Цели и основания (GDPR)
+- **Provide and improve the app** — legitimate interests (Art. 6(1)(f)).  
+- **Diagnostics/crash reporting (optional)** — your consent (Art. 6(1)(a)).  
+- **Compliance** — legal obligations where applicable (Art. 6(1)(c)).
+
+- **Предоставление и улучшение приложения** — законный интерес (ст. 6(1)(f) GDPR).  
+- **Диагностика/краш-отчёты (опционально)** — ваше согласие (ст. 6(1)(a)).  
+- **Соблюдение требований закона** — при необходимости (ст. 6(1)(c)).
+
+## 4. Storage & Retention / Хранение и сроки
+- On-device data stays on your device until you delete it or uninstall the app.  
+- Optional diagnostics, if enabled, are retained by our providers for a limited period (e.g., up to **90** days).
+
+- Данные на устройстве остаются у вас до удаления или деинсталляции.  
+- Опциональная диагностика, если включена, хранится у провайдеров ограниченное время (например, до **90** дней.
+
+## 5. Sharing & Transfers / Передача и трансграничность
+We do **not** sell your data. We may use service providers (e.g., crash reporting) acting under our instructions. Some providers may be located outside your country; when applicable, we rely on appropriate safeguards.  
+Мы **не** продаём данные. Возможны провайдеры услуг (например, краш-отчёты), действующие по нашим инструкциям. Отдельные провайдеры могут находиться за пределами вашей страны; в этом случае применяются соответствующие меры защиты.
+
+## 6. Permissions / Разрешения
+The app may request access to files/storage to let you import receipts/PDFs; notifications are optional.  
+Приложение может запрашивать доступ к файлам/хранилищу для импорта чеков/PDF; уведомления — опционально.
+
+## 7. Your Rights (GDPR) / Ваши права
+Access, rectification, erasure, restriction, portability, objection, and withdrawal of consent (without affecting prior processing). You can exercise rights via the contact link above.  
+Доступ, исправление, удаление, ограничение, переносимость, возражение и отзыв согласия (без воздействия на предшествующую обработку). Реализация прав — через ссылку для связи выше.
+
+## 8. Children / Дети
+The app is not directed to children under 16.  
+Приложение не предназначено для детей младше 16 лет.
+
+## 9. Changes / Изменения
+We may update this Policy. Material changes will be highlighted in the repository/app.  
+Мы можем обновлять Политику. Существенные изменения будут отмечены в репозитории/приложении.
+
+## 10. Contact / Контакты
+Controller: **Varkan** — use the issue tracker to contact us: https://github.com/shatokh/Receipts/issues

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,85 @@
+# Terms of Use — Receipts
+_Effective date:_ 2025-10-12  
+_Owner:_ Varkan — https://github.com/shatokh/Receipts/issues
+
+## 1. Acceptance
+By downloading or using “Receipts” (the “App”), you agree to these Terms. If you do not agree, do not use the App.
+
+## 2. License
+We grant you a personal, limited, revocable, non-transferable license to use the App for its intended purpose. You may not reverse engineer, decompile, or attempt to extract the source code, except where permitted by law.
+
+## 3. Your Content
+You are responsible for the content you import (e.g., receipts/PDFs) and for complying with applicable laws.
+
+## 4. Acceptable Use
+Do not misuse the App, interfere with its operation, or use it to infringe rights or laws.
+
+## 5. In-App Payments
+**No in-app purchases or subscriptions at this time.**
+
+## 6. Third-Party Services
+The App may rely on optional third-party services (e.g., crash reporting). Their terms may apply.
+
+## 7. Disclaimers
+The App is provided “AS IS” without warranties. We do not warrant uninterrupted or error-free operation.
+
+## 8. Limitation of Liability
+To the maximum extent permitted by law, we shall not be liable for indirect, incidental, or consequential damages, or for loss of data. Our total liability will not exceed the amount you paid for the App in the last 12 months (often zero).
+
+## 9. Termination
+We may suspend or terminate access if you materially breach these Terms. You may stop using the App at any time.
+
+## 10. Governing Law
+These Terms are governed by the laws of **Poland**.
+
+## 11. Changes
+We may update these Terms; continued use after updates means acceptance.
+
+## 12. Contact
+Varkan — https://github.com/shatokh/Receipts/issues
+
+> **iOS Note:** If downloaded via the App Store, your use is also governed by Apple’s Licensed Application End User License Agreement (EULA).
+
+---
+
+# Условия использования — Receipts
+_Дата вступления в силу:_ 2025-10-12  
+_Владелец:_ Varkan — https://github.com/shatokh/Receipts/issues
+
+## 1. Принятие условий
+Скачивая или используя «Receipts» (далее — «Приложение»), вы соглашаетесь с настоящими Условиями. Если вы не согласны — не используйте Приложение.
+
+## 2. Лицензия
+Мы предоставляем личную, ограниченную, отзывную, непередаваемую лицензию для использования Приложения по назначению. Запрещается декомпиляция, обратная разработка и иные попытки получить исходный код, кроме случаев, разрешённых законом.
+
+## 3. Ваш контент
+Вы несёте ответственность за контент, который импортируете (например, чеки/PDF), и соблюдение применимого законодательства.
+
+## 4. Допустимое использование
+Не допускается злоупотребление Приложением, вмешательство в его работу или использование с нарушением прав/закона.
+
+## 5. Платежи в приложении
+**В настоящий момент в приложении нет покупок или подписок.**
+
+## 6. Сторонние сервисы
+Приложение может использовать опциональные сторонние сервисы (например, отчёты о сбоях). На них могут распространяться их условия.
+
+## 7. Ограничение гарантий
+Приложение предоставляется «КАК ЕСТЬ», без каких-либо гарантий, включая бесперебойность или отсутствие ошибок.
+
+## 8. Ограничение ответственности
+В максимальной степени, допустимой законом, мы не несём ответственности за косвенные/случайные/последующие убытки и утрату данных. Совокупная ответственность ограничивается суммой, уплаченной вами за Приложение за последние 12 месяцев (часто ноль).
+
+## 9. Прекращение
+Мы можем приостановить или прекратить доступ при существенном нарушении Условий. Вы можете прекратить использование в любой момент.
+
+## 10. Применимое право
+Настоящие Условия регулируются правом **Польши**.
+
+## 11. Изменения
+Мы можем обновлять Условия; продолжение использования означает согласие.
+
+## 12. Контакты
+Varkan — https://github.com/shatokh/Receipts/issues
+
+> **Для iOS:** при загрузке из App Store также действует стандартная EULA Apple.


### PR DESCRIPTION
## Summary
- add privacy policy covering English and Russian audiences under docs/privacy.md
- add bilingual terms of use for Receipts in docs/terms.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb90e1b1c8832fb9451a58de81f876