### PR TITLE
Reduce Android debug artifact retention to 4 days

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -46,4 +46,4 @@ jobs:
           name: biedronka_expenses-debug-${{ github.sha }}
           path: ${{ env.PROJECT_DIR }}/build/app/outputs/flutter-apk/app-debug.apk
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 4


### PR DESCRIPTION
## Summary
- decrease the retention period for the Android debug workflow artifact to four days to align with updated requirements

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eba22a5ff4832fa2f414d483b27803