### PR TITLE
Fix PDF import fallback handling

### DIFF
--- a/lib/features/import/import_service.dart
+++ b/lib/features/import/import_service.dart
@@ -74,11 +74,17 @@ class ImportService {
   Future<Receipt> _parseReceipt(String safUri) async {
     try {
       final pages = await pdf.extractTextPages(safUri);
+      if (pages.isEmpty) {
+        throw const FormatException('Empty PDF content');
+      }
+
       final text = pages.join('\n');
+      if (text.trim().isEmpty) {
+        throw const FormatException('Empty PDF content');
+      }
+
       return parser.parse(text);
     } on PdfTextExtractionException {
-      return _parseTextFile(safUri);
-    } on FormatException {
       return _parseTextFile(safUri);
     }
   }


### PR DESCRIPTION
## Summary
- avoid falling back to text-file parsing when PDF content parses but fails validation
- surface a clearer error when the extracted PDF text is empty instead of masking it as an unsupported source

## Testing
- flutter test test/import_pipeline_test.dart *(fails: Because every version of integration_test from sdk depends on collection 1.19.0 and receipts depends on collection ^1.19.1, integration_test from sdk is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ebbeebc3ec832fa4b120960fe9f7bd