### PR TITLE
Handle embedded JSON payloads when importing receipts

### DIFF
--- a/test/import_pipeline_test.dart
+++ b/test/import_pipeline_test.dart
@@ -117,4 +117,19 @@ void main() {
     expect(result.status, ImportStatus.success);
     expect(result.receiptId, isNotEmpty);
   });
+
+  test('imports JSON payload returned from PDF extraction', () async {
+    final jsonText = await File('assets/sample_receipt.json').readAsString();
+
+    when(() => pdf.fileHash('uri://embedded-json'))
+        .thenAnswer((_) async => 'embedded-json-hash');
+    when(() => pdf.extractTextPages('uri://embedded-json'))
+        .thenAnswer((_) async => [jsonText]);
+    when(() => pdf.pageCount('uri://embedded-json')).thenAnswer((_) async => 1);
+
+    final result = await importService.importOne('uri://embedded-json');
+
+    expect(result.status, ImportStatus.success);
+    expect(result.receiptId, isNotEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
- update the Android PDF text extractor to look for embedded receipt payloads and decode JSON that is wrapped in zip or gzip attachments
- fall back to returning the embedded payload when found so JSON-based receipts import successfully instead of reporting empty content
- extend the import pipeline test to cover the case where the extractor returns a JSON payload directly

## Testing
- flutter test *(fails: integration_test from the flutter SDK pins collection 1.19.0 while the project requires ^1.19.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc88216ec832f93165ea80e13fbb6