### PR TITLE
Refine category grouping and top categories display

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -2,6 +2,8 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:path/path.dart';
 import 'package:flutter/foundation.dart';
 
+import 'package:receipts/domain/category_definitions.dart';
+
 class DatabaseHelper {
   static Database? _database;
   static const String dbName = 'receipts.db';
@@ -141,17 +143,11 @@ class DatabaseHelper {
   }
 
   static Future<void> _insertDefaultCategories(Database db) async {
-    final categories = [
-      {'id': 'produce', 'name': 'Produce'},
-      {'id': 'meat', 'name': 'Meat'},
-      {'id': 'dairy', 'name': 'Dairy'},
-      {'id': 'household', 'name': 'Household'},
-      {'id': 'bakery', 'name': 'Bakery'},
-      {'id': 'other', 'name': 'Other'},
-    ];
-
-    for (final category in categories) {
-      await db.insert('categories', category);
+    for (final definition in categoryDefinitions) {
+      await db.insert('categories', {
+        'id': definition.id,
+        'name': definition.label,
+      });
     }
 
     // Insert default merchants

--- a/lib/data/repositories/category_repository.dart
+++ b/lib/data/repositories/category_repository.dart
@@ -1,4 +1,5 @@
 import 'package:receipts/data/database.dart';
+import 'package:receipts/domain/category_definitions.dart';
 import 'package:receipts/domain/models/category.dart';
 import 'package:receipts/domain/models/monthly_total.dart';
 
@@ -16,11 +17,8 @@ class CategoryRepository {
     return Category.fromMap(maps.first);
   }
 
-  Future<List<CategoryMonthTotal>> getTopCategoriesForMonth(
-    int year, 
-    int month, 
-    {int limit = 5}
-  ) async {
+  Future<List<CategoryMonthTotal>> getTopCategoriesForMonth(int year, int month,
+      {int limit = 5}) async {
     final db = await DatabaseHelper.database;
     final maps = await db.query(
       'category_month_totals',
@@ -40,7 +38,7 @@ class CategoryRepository {
       where: 'year = ? AND month = ?',
       whereArgs: [year, month],
     );
-    
+
     if (result.isEmpty) return 0.0;
     return result.first['total'] as double;
   }
@@ -49,41 +47,18 @@ class CategoryRepository {
     final db = await DatabaseHelper.database;
     final startOfMonth = DateTime(year, month).millisecondsSinceEpoch;
     final startOfNextMonth = DateTime(year, month + 1).millisecondsSinceEpoch;
-    
+
     final result = await db.query(
       'receipts',
       columns: ['COUNT(*) as count'],
       where: 'purchase_ts >= ? AND purchase_ts < ?',
       whereArgs: [startOfMonth, startOfNextMonth],
     );
-    
+
     return result.first['count'] as int;
   }
 
   Future<String> categorizeName(String itemName) async {
-    final lowercaseName = itemName.toLowerCase();
-    
-    // Polish categorization rules
-    if (_containsAny(lowercaseName, ['mleko', 'ser', 'jogurt', 'masło', 'śmietana', 'twaróg'])) {
-      return 'dairy';
-    }
-    if (_containsAny(lowercaseName, ['mięso', 'kiełbasa', 'szynka', 'kurczak', 'wołowina', 'wieprzowina'])) {
-      return 'meat';
-    }
-    if (_containsAny(lowercaseName, ['chleb', 'bułka', 'pieczywo', 'bagietka'])) {
-      return 'bakery';
-    }
-    if (_containsAny(lowercaseName, ['jabłko', 'banan', 'pomidor', 'ogórek', 'warzywa', 'owoce', 'sałata'])) {
-      return 'produce';
-    }
-    if (_containsAny(lowercaseName, ['papier', 'detergent', 'mydło', 'proszek', 'chemia', 'ręcznik'])) {
-      return 'household';
-    }
-    
-    return 'other';
-  }
-
-  bool _containsAny(String text, List<String> keywords) {
-    return keywords.any((keyword) => text.contains(keyword));
+    return categorizeItemName(itemName);
   }
 }

--- a/lib/domain/category_definitions.dart
+++ b/lib/domain/category_definitions.dart
@@ -1,0 +1,274 @@
+class CategoryIds {
+  static const freshProduce = 'fresh_produce';
+  static const dairyEggsBakery = 'dairy_eggs_bakery';
+  static const packagedPantry = 'packaged_pantry';
+  static const drinksSnacks = 'drinks_snacks';
+  static const householdGoods = 'household_goods';
+  static const misc = 'misc';
+}
+
+class CategoryDefinition {
+  const CategoryDefinition({
+    required this.id,
+    required this.label,
+    this.keywords = const <String>[],
+    this.legacyIds = const <String>[],
+  });
+
+  final String id;
+  final String label;
+  final List<String> keywords;
+  final List<String> legacyIds;
+}
+
+const List<CategoryDefinition> categoryDefinitions = [
+  CategoryDefinition(
+    id: CategoryIds.freshProduce,
+    label: 'Fresh Produce & Vegetables',
+    keywords: const [
+      'jabł',
+      'jabl',
+      'banan',
+      'pomidor',
+      'ogór',
+      'ogor',
+      'warzyw',
+      'owoc',
+      'sałat',
+      'salat',
+      'ziemni',
+      'marchew',
+      'papryk',
+      'kapust',
+      'grzyb',
+      'por',
+      'pietruszk',
+      'koper',
+      'fruit',
+      'vegetable',
+      'fresh',
+      'greens',
+      'lettuc',
+      'apple',
+      'banana',
+      'tomato',
+      'cucumber',
+      'berry',
+      'herb',
+    ],
+    legacyIds: const ['produce'],
+  ),
+  CategoryDefinition(
+    id: CategoryIds.dairyEggsBakery,
+    label: 'Dairy, Eggs & Bakery',
+    keywords: const [
+      'mleko',
+      'milk',
+      'ser',
+      'cheese',
+      'jogurt',
+      'yoghurt',
+      'yogurt',
+      'masł',
+      'masl',
+      'butter',
+      'śmiet',
+      'smiet',
+      'cream',
+      'twaróg',
+      'twarog',
+      'kefir',
+      'jaja',
+      'egg',
+      'chleb',
+      'bread',
+      'buł',
+      'bul',
+      'pieczy',
+      'bagiet',
+      'ciasto',
+      'cake',
+      'croissant',
+      'pastr',
+      'bagel',
+      'roll',
+      'bake',
+      'bakery',
+    ],
+    legacyIds: const ['dairy', 'bakery'],
+  ),
+  CategoryDefinition(
+    id: CategoryIds.packagedPantry,
+    label: 'Packaged & Pantry Foods',
+    keywords: const [
+      'makaron',
+      'pasta',
+      'ryż',
+      'ryz',
+      'rice',
+      'kasz',
+      'cereal',
+      'płatk',
+      'platk',
+      'mąk',
+      'mak',
+      'flour',
+      'cukier',
+      'sugar',
+      'sól',
+      'sol',
+      'salt',
+      'olej',
+      'oil',
+      'oliw',
+      'puszk',
+      'konserw',
+      'can',
+      'canned',
+      'sos',
+      'sauce',
+      'przypraw',
+      'spice',
+      'zupa',
+      'soup',
+      'mroż',
+      'mroz',
+      'frozen',
+      'mięso',
+      'mieso',
+      'kiełb',
+      'kielb',
+      'szynk',
+      'kurczak',
+      'wołow',
+      'wolow',
+      'wieprz',
+      'indyk',
+      'fish',
+      'łosoś',
+      'losos',
+      'tuńczyk',
+      'tunczyk',
+      'broth',
+      'bouillon',
+    ],
+    legacyIds: const ['meat'],
+  ),
+  CategoryDefinition(
+    id: CategoryIds.drinksSnacks,
+    label: 'Drinks & Snacks',
+    keywords: const [
+      'napój',
+      'napoj',
+      'sok',
+      'juice',
+      'cola',
+      'pepsi',
+      'piwo',
+      'beer',
+      'wino',
+      'wine',
+      'kawa',
+      'coffee',
+      'herbat',
+      'tea',
+      'woda',
+      'water',
+      'chips',
+      'crisps',
+      'snack',
+      'przekąsk',
+      'przekask',
+      'baton',
+      'bar',
+      'czekol',
+      'chocolate',
+      'energet',
+      'energy',
+      'drink',
+      'nap',
+      'fanta',
+      'sprite',
+      'lemon',
+    ],
+  ),
+  CategoryDefinition(
+    id: CategoryIds.householdGoods,
+    label: 'Household Goods',
+    keywords: const [
+      'papier',
+      'deterg',
+      'mydł',
+      'mydl',
+      'soap',
+      'proszek',
+      'chemia',
+      'środek',
+      'srodek',
+      'clean',
+      'ręcz',
+      'recz',
+      'pranie',
+      'laundry',
+      'zmyw',
+      'dish',
+      'płyn',
+      'plyn',
+      'gąb',
+      'gab',
+      'sponge',
+      'świec',
+      'swiec',
+      'świecz',
+      'worki',
+      'trash',
+      'mop',
+      'broom',
+      'toalet',
+      'toilet',
+    ],
+    legacyIds: const ['household'],
+  ),
+  CategoryDefinition(
+    id: CategoryIds.misc,
+    label: 'Miscellaneous / Other',
+    legacyIds: const ['other'],
+  ),
+];
+
+final Map<String, CategoryDefinition> _definitionsById = {
+  for (final definition in categoryDefinitions) definition.id: definition,
+};
+
+final Map<String, String> _legacyIdToDefinitionId = {
+  for (final definition in categoryDefinitions)
+    for (final legacyId in definition.legacyIds) legacyId: definition.id,
+};
+
+String normalizeCategoryId(String? rawId) {
+  if (rawId == null || rawId.isEmpty) {
+    return CategoryIds.misc;
+  }
+  final id = rawId.trim();
+  if (_definitionsById.containsKey(id)) {
+    return id;
+  }
+  final legacyMapping = _legacyIdToDefinitionId[id];
+  if (legacyMapping != null) {
+    return legacyMapping;
+  }
+  return CategoryIds.misc;
+}
+
+String categorizeItemName(String name) {
+  final lower = name.toLowerCase();
+  for (final definition in categoryDefinitions) {
+    if (definition.keywords.isEmpty) {
+      continue;
+    }
+    if (definition.keywords.any((keyword) => lower.contains(keyword))) {
+      return definition.id;
+    }
+  }
+  return CategoryIds.misc;
+}

--- a/lib/domain/parsing/receipt_parser.dart
+++ b/lib/domain/parsing/receipt_parser.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:receipts/domain/category_definitions.dart';
 import 'package:receipts/domain/models/line_item.dart';
 import 'package:receipts/domain/models/receipt.dart';
 
@@ -18,22 +19,6 @@ class ReceiptParser {
       caseSensitive: false);
   static final RegExp _discountLineRegex =
       RegExp(r'(-?\d+(?:[,.]\d+)?)\s*PLN', caseSensitive: false);
-  static final Map<String, List<String>> _categoryKeywords = {
-    'dairy': ['mleko', 'ser', 'jogurt', 'masło', 'śmiet', 'twaróg', 'kefir'],
-    'meat': ['mięso', 'kiełb', 'szynk', 'kurczak', 'wołow', 'wieprz', 'indyk'],
-    'bakery': ['chleb', 'bułk', 'pieczy', 'bagiet', 'ciasto'],
-    'produce': ['jabł', 'banan', 'pomidor', 'ogór', 'warzyw', 'owoc', 'sałat'],
-    'household': [
-      'papier',
-      'deterg',
-      'mydł',
-      'proszek',
-      'chemia',
-      'ręcz',
-      'środek'
-    ],
-  };
-
   Receipt parse(String rawText) {
     final maybeJson = rawText.trimLeft();
     if (maybeJson.startsWith('{')) {
@@ -523,13 +508,7 @@ class ReceiptParser {
   }
 
   String _categorize(String name) {
-    final lower = name.toLowerCase();
-    for (final entry in _categoryKeywords.entries) {
-      if (entry.value.any((keyword) => lower.contains(keyword))) {
-        return entry.key;
-      }
-    }
-    return 'other';
+    return categorizeItemName(name);
   }
 
   double _vatRateFromCode(String? code) {

--- a/lib/features/dashboard/dashboard_view.dart
+++ b/lib/features/dashboard/dashboard_view.dart
@@ -98,7 +98,7 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
                 ),
                 const SizedBox(height: AppSpacing.lg),
                 Text(
-                  'Top categories — ${monthFormat.format(selectedMonth)}',
+                  'Spending by category — ${monthFormat.format(selectedMonth)}',
                   style: AppTextStyles.titleMedium.copyWith(
                     color: AppColors.textPrimary,
                   ),
@@ -448,12 +448,15 @@ class _TopCategoriesSection extends StatelessWidget {
   Widget build(BuildContext context) {
     return overview.when(
       data: (data) {
-        if (data.topCategories.isEmpty) {
+        final hasSpending =
+            data.topCategories.any((category) => category.amount > 0);
+
+        if (!hasSpending) {
           return Card(
             child: Padding(
               padding: const EdgeInsets.all(AppSpacing.md),
               child: Text(
-                'No categories yet for this month',
+                'No categorized spending for this month yet',
                 style: AppTextStyles.bodyMedium.copyWith(
                   color: AppColors.textSecondary,
                 ),
@@ -487,7 +490,7 @@ class _TopCategoriesSection extends StatelessWidget {
                 ),
                 const SizedBox(height: AppSpacing.sm),
                 Text(
-                  'Top 5 of ${currencyFormat.format(data.total)}',
+                  'Total — ${currencyFormat.format(data.total)}',
                   style: AppTextStyles.labelSmall.copyWith(
                     color: AppColors.textSecondary,
                   ),

--- a/lib/features/month/month_view.dart
+++ b/lib/features/month/month_view.dart
@@ -35,9 +35,8 @@ class MonthView extends ConsumerWidget {
     );
 
     final overviewData = monthOverviewAsync.asData?.value;
-    final totalValue = overviewData != null
-        ? currencyFormat.format(overviewData.total)
-        : '—';
+    final totalValue =
+        overviewData != null ? currencyFormat.format(overviewData.total) : '—';
     final receiptsCount = overviewData?.receiptsCount ?? 0;
 
     return Scaffold(
@@ -54,6 +53,13 @@ class MonthView extends ConsumerWidget {
               selectedMonth: DateTime(selectedMonth.year, selectedMonth.month),
             ),
             const SizedBox(height: AppSpacing.lg),
+            Text(
+              'Spending by category — ${monthFormat.format(selectedMonth)}',
+              style: AppTextStyles.titleMedium.copyWith(
+                color: AppColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
             _CategoryBreakdown(overview: monthOverviewAsync),
             const SizedBox(height: AppSpacing.lg),
             Row(
@@ -164,7 +170,8 @@ class MonthView extends ConsumerWidget {
     List<MonthlyTotal> totals,
     DateTime selectedMonth,
   ) {
-    final normalizedSelected = DateTime(selectedMonth.year, selectedMonth.month);
+    final normalizedSelected =
+        DateTime(selectedMonth.year, selectedMonth.month);
     final uniqueMonths = <DateTime>{};
 
     for (final total in totals) {
@@ -174,16 +181,17 @@ class MonthView extends ConsumerWidget {
     }
 
     if (uniqueMonths.isEmpty) {
-      uniqueMonths.addAll(totals.map((total) => DateTime(total.year, total.month)));
+      uniqueMonths
+          .addAll(totals.map((total) => DateTime(total.year, total.month)));
     }
 
     uniqueMonths.add(normalizedSelected);
-    final months = uniqueMonths.toList()
-      ..sort((a, b) => a.compareTo(b));
+    final months = uniqueMonths.toList()..sort((a, b) => a.compareTo(b));
     return months;
   }
 
-  bool _isSameMonth(DateTime a, DateTime b) => a.year == b.year && a.month == b.month;
+  bool _isSameMonth(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month;
 }
 
 class _MonthPicker extends ConsumerWidget {
@@ -199,7 +207,9 @@ class _MonthPicker extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final monthFormat = DateFormat('MMMM yyyy');
     final value = months.firstWhere(
-      (month) => month.year == selectedMonth.year && month.month == selectedMonth.month,
+      (month) =>
+          month.year == selectedMonth.year &&
+          month.month == selectedMonth.month,
       orElse: () => selectedMonth,
     );
 
@@ -241,12 +251,15 @@ class _CategoryBreakdown extends StatelessWidget {
   Widget build(BuildContext context) {
     return overview.when(
       data: (data) {
-        if (data.topCategories.isEmpty) {
+        final hasSpending =
+            data.topCategories.any((category) => category.amount > 0);
+
+        if (!hasSpending) {
           return Card(
             child: Padding(
               padding: const EdgeInsets.all(AppSpacing.md),
               child: Text(
-                'No categories tracked for this month yet',
+                'No categorized spending for this month yet',
                 style: AppTextStyles.bodyMedium.copyWith(
                   color: AppColors.textSecondary,
                 ),
@@ -280,7 +293,7 @@ class _CategoryBreakdown extends StatelessWidget {
                 ),
                 const SizedBox(height: AppSpacing.sm),
                 Text(
-                  'Top 5 of ${currencyFormat.format(data.total)}',
+                  'Total — ${currencyFormat.format(data.total)}',
                   style: AppTextStyles.labelSmall.copyWith(
                     color: AppColors.textSecondary,
                   ),


### PR DESCRIPTION
## Summary
- add a shared category definition map with keywords, legacy mappings, and ids for the six new buckets
- normalize category aggregation and categorization logic to use the new definitions across repositories and parsing
- refresh the dashboard and month views to show the new category list with total summaries when spending exists

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68efd33c93e4832fba0e803c2317b1b1