### PR TITLE
Install Android NDK during Android debug CI build

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -32,6 +32,11 @@ jobs:
           flutter-version: "3.35.3"
           channel: "stable"
 
+      - name: Install Android NDK 27.0.12077973
+        run: |
+          yes | "${ANDROID_SDK_ROOT:-$ANDROID_HOME}"/cmdline-tools/latest/bin/sdkmanager \
+            --sdk_root="${ANDROID_SDK_ROOT:-$ANDROID_HOME}" "ndk;27.0.12077973"
+
       - name: Flutter pub get
         working-directory: ${{ env.PROJECT_DIR }}
         run: flutter pub get


### PR DESCRIPTION
## Summary
- install the Android NDK 27.0.12077973 in the Android debug workflow so the build can find a complete NDK installation

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f0c78acd34832fb6be0090a9e5fc9e