### PR TITLE
Fix PDF embedded files tree type for Kotlin compile

### DIFF
--- a/android/app/src/main/kotlin/app/receipts/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/receipts/MainActivity.kt
@@ -9,7 +9,7 @@ import io.flutter.plugin.common.MethodChannel
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import com.tom_roush.pdfbox.pdmodel.PDDocument
 import com.tom_roush.pdfbox.pdmodel.PDDocumentNameDictionary
-import com.tom_roush.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode
+import com.tom_roush.pdfbox.pdmodel.common.PDNameTreeNode
 import com.tom_roush.pdfbox.text.PDFTextStripper
 import com.tom_roush.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification
 import com.tom_roush.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile
@@ -171,7 +171,7 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun extractFromEmbeddedTree(
-        node: PDEmbeddedFilesNameTreeNode?
+        node: PDNameTreeNode<PDComplexFileSpecification>?,
     ): String? {
         if (node == null) {
             return null


### PR DESCRIPTION
## Summary
- replace the deprecated `PDEmbeddedFilesNameTreeNode` usage with the generic `PDNameTreeNode` for embedded file traversal

## Testing
- `FLUTTER_SDK=/opt/flutter gradle -p android app:compileDebugKotlin -x app:compileFlutterBuildDebug --stacktrace --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68f12d538138832f9d52a6604cf6a252