### PR TITLE
Add localization with English and Russian languages

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,7 @@ import 'package:receipts/features/month/month_view.dart';
 import 'package:receipts/features/receipts/receipts_view.dart';
 import 'package:receipts/features/receipt_details/receipt_details_view.dart';
 import 'package:receipts/features/import/import_view.dart';
+import 'package:receipts/features/settings/language_page.dart';
 import 'package:receipts/features/settings/settings_view.dart';
 import 'package:receipts/app/main_scaffold.dart';
 
@@ -33,6 +34,10 @@ final router = GoRouter(
         GoRoute(
           path: '/settings',
           builder: (context, state) => const SettingsView(),
+        ),
+        GoRoute(
+          path: '/settings/language',
+          builder: (context, state) => const LanguagePage(),
         ),
         GoRoute(
           path: '/import',

--- a/lib/core/localization/locale_controller.dart
+++ b/lib/core/localization/locale_controller.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final localeProvider = StateNotifierProvider<LocaleController, Locale>(
+  (ref) => LocaleController(),
+);
+
+class LocaleController extends StateNotifier<Locale> {
+  LocaleController() : super(const Locale('en')) {
+    _load();
+  }
+
+  static const _prefsKey = 'localeCode';
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final code = prefs.getString(_prefsKey);
+    if (code != null && code.isNotEmpty) {
+      state = Locale(code);
+    }
+  }
+
+  Future<void> setLocale(Locale locale) async {
+    if (state == locale) {
+      return;
+    }
+    state = locale;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, locale.languageCode);
+  }
+}

--- a/lib/features/settings/language_page.dart
+++ b/lib/features/settings/language_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:receipts/core/localization/locale_controller.dart';
+
+class LanguagePage extends ConsumerWidget {
+  const LanguagePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final t = AppLocalizations.of(context)!;
+    final current = ref.watch(localeProvider);
+    final controller = ref.read(localeProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(t.languageTitle)),
+      body: ListView(
+        children: [
+          ListTile(title: Text(t.chooseLanguage)),
+          const Divider(),
+          RadioListTile<Locale>(
+            value: const Locale('en'),
+            groupValue: current,
+            onChanged: (_) => controller.setLocale(const Locale('en')),
+            title: Text(t.english),
+          ),
+          RadioListTile<Locale>(
+            value: const Locale('ru'),
+            groupValue: current,
+            onChanged: (_) => controller.setLocale(const Locale('ru')),
+            title: Text(t.russian),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_view.dart
+++ b/lib/features/settings/settings_view.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:receipts/theme.dart';
+import 'package:go_router/go_router.dart';
+
 import 'package:receipts/app/providers.dart';
+import 'package:receipts/core/localization/locale_controller.dart';
+import 'package:receipts/theme.dart';
 
 class SettingsView extends ConsumerWidget {
   const SettingsView({super.key});
@@ -9,14 +13,44 @@ class SettingsView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sentryEnabled = ref.watch(sentryEnabledProvider);
-    
+    final t = AppLocalizations.of(context)!;
+    final locale = ref.watch(localeProvider);
+
+    final languageName = switch (locale.languageCode) {
+      'ru' => t.russian,
+      _ => t.english,
+    };
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Settings'),
+        title: Text(t.settingsTitle),
       ),
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.md),
         children: [
+          _SettingsSection(
+            title: t.languageTitle,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.language),
+                title: Text(
+                  t.languageTitle,
+                  style: AppTextStyles.bodyLarge.copyWith(
+                    color: AppColors.textPrimary,
+                  ),
+                ),
+                subtitle: Text(
+                  languageName,
+                  style: AppTextStyles.bodyMedium.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
+                ),
+                onTap: () => context.push('/settings/language'),
+                contentPadding: EdgeInsets.zero,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.lg),
           _SettingsSection(
             title: 'Crash reports',
             children: [
@@ -35,7 +69,9 @@ class SettingsView extends ConsumerWidget {
                 ),
                 value: sentryEnabled,
                 onChanged: (value) async {
-                  await ref.read(sentryEnabledProvider.notifier).setEnabled(value);
+                  await ref
+                      .read(sentryEnabledProvider.notifier)
+                      .setEnabled(value);
 
                   final message = value
                       ? 'Crash reporting enabled'
@@ -177,7 +213,7 @@ class SettingsView extends ConsumerWidget {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Cancel'),
+            child: Text(AppLocalizations.of(context)!.cancel),
           ),
           TextButton(
             onPressed: () {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,16 @@
+{
+  "@@locale": "en",
+  "appTitle": "Receipts",
+  "settingsTitle": "Settings",
+  "languageTitle": "Language",
+  "chooseLanguage": "Choose language",
+  "english": "English",
+  "russian": "Russian",
+  "aboutLegal": "Privacy & Terms",
+  "privacyPolicy": "Privacy Policy",
+  "termsOfUse": "Terms of Use",
+  "openInBrowser": "Open in browser",
+  "couldNotOpenLink": "Could not open link",
+  "ok": "OK",
+  "cancel": "Cancel"
+}

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,0 +1,16 @@
+{
+  "@@locale": "ru",
+  "appTitle": "Receipts",
+  "settingsTitle": "Настройки",
+  "languageTitle": "Язык",
+  "chooseLanguage": "Выберите язык",
+  "english": "Английский",
+  "russian": "Русский",
+  "aboutLegal": "Политика и Условия",
+  "privacyPolicy": "Политика конфиденциальности",
+  "termsOfUse": "Условия использования",
+  "openInBrowser": "Открыть в браузере",
+  "couldNotOpenLink": "Не удалось открыть ссылку",
+  "ok": "ОК",
+  "cancel": "Отмена"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -6,6 +7,7 @@ import 'package:workmanager/workmanager.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/app/router.dart';
+import 'package:receipts/core/localization/locale_controller.dart';
 import 'package:receipts/data/database.dart';
 import 'package:receipts/data/repositories/settings_repository.dart';
 import 'package:receipts/theme.dart';
@@ -65,16 +67,21 @@ void main() async {
   }
 }
 
-class ReceiptsApp extends StatelessWidget {
+class ReceiptsApp extends ConsumerWidget {
   const ReceiptsApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(localeProvider);
+
     return MaterialApp.router(
-      title: 'Receipts',
       debugShowCheckedModeBanner: false,
       theme: appTheme,
       routerConfig: router,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: locale,
+      onGenerateTitle: (ctx) => AppLocalizations.of(ctx)!.appTitle,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   collection:
     dependency: "direct main"
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -179,6 +179,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -267,26 +272,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -307,10 +312,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -323,10 +328,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -355,10 +360,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -584,10 +589,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.12.0"
   state_notifier:
     dependency: transitive
     description:
@@ -600,10 +605,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -640,10 +645,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -664,10 +669,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -733,5 +738,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_riverpod: ^2.6.1
   go_router: ^14.6.2
   sqflite: ^2.4.1
@@ -38,8 +40,10 @@ dependency_overrides:
   # The Flutter SDK's integration_test package still pins collection to 1.19.0.
   # Force the workspace to use the ^1.19.1 constraint that the app requires.
   collection: ^1.19.1
+  intl: ^0.20.1
 
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/sample_receipt.txt


### PR DESCRIPTION
## Summary
- enable Flutter localization code generation and provide English/Russian ARB resources
- add a locale controller that persists the selected language and wire localization through MaterialApp
- add a settings entry and page to switch languages at runtime

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68f67d056004832fac8e37ae044639fb