### PR TITLE
Add Russian localizations and use direct l10n generation

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,4 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+synthetic-package: false

--- a/lib/features/dashboard/dashboard_view.dart
+++ b/lib/features/dashboard/dashboard_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:receipts/l10n/app_localizations.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/domain/models/dashboard_kpis.dart';
@@ -23,6 +24,7 @@ class DashboardView extends ConsumerStatefulWidget {
 class _DashboardViewState extends ConsumerState<DashboardView> {
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     final selectedMonth = ref.watch(selectedMonthProvider);
     final monthlyTotalsAsync = ref.watch(monthlyTotalsProvider);
     final monthOverviewAsync = ref.watch(monthOverviewProvider(selectedMonth));
@@ -33,13 +35,13 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Spending dashboard'),
+        title: Text(t.dashboardTitle),
         actions: [
           IconButton(
             key: const ValueKey('nav_import_action'),
             icon: const Icon(Icons.add),
             onPressed: () => context.go('/import'),
-            tooltip: 'Import PDF',
+            tooltip: t.importPdf,
           ),
         ],
       ),
@@ -66,7 +68,7 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
                   children: [
                     Expanded(
                       child: Text(
-                        'Selected month',
+                        t.selectedMonthLabel,
                         style: AppTextStyles.bodyLarge.copyWith(
                           color: AppColors.textPrimary,
                         ),
@@ -90,7 +92,7 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
                     borderRadius: BorderRadius.circular(16),
                   ),
                   child: Text(
-                    'All data is processed on device',
+                    t.onDeviceProcessing,
                     style: AppTextStyles.labelSmall.copyWith(
                       color: AppColors.textSecondary,
                     ),
@@ -98,15 +100,15 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
                 ),
                 const SizedBox(height: AppSpacing.lg),
                 Text(
-                  'Spending by category — ${monthFormat.format(selectedMonth)}',
+                  t.spendingByCategoryForMonth(
+                    monthFormat.format(selectedMonth),
+                  ),
                   style: AppTextStyles.titleMedium.copyWith(
                     color: AppColors.textPrimary,
                   ),
                 ),
                 const SizedBox(height: AppSpacing.md),
-                _TopCategoriesSection(
-                  overview: monthOverviewAsync,
-                ),
+                _TopCategoriesSection(overview: monthOverviewAsync),
                 const SizedBox(height: AppSpacing.lg),
                 _QuickInsights(
                   overview: monthOverviewAsync,
@@ -184,6 +186,7 @@ class _KPICards extends StatelessWidget {
       symbol: 'PLN ',
       decimalDigits: 2,
     );
+    final t = AppLocalizations.of(context)!;
     final data = kpis.asData?.value;
     final isLoading = kpis.isLoading;
 
@@ -197,7 +200,7 @@ class _KPICards extends StatelessWidget {
       children: [
         Expanded(
           child: _KPICard(
-            title: 'Total (30d)',
+            title: t.totalLast30Days,
             value: totalValue,
             isLoading: isLoading && data == null,
           ),
@@ -205,7 +208,7 @@ class _KPICards extends StatelessWidget {
         const SizedBox(width: AppSpacing.md),
         Expanded(
           child: _KPICard(
-            title: 'Average receipt',
+            title: t.averageReceipt,
             value: averageValue,
             isLoading: isLoading && data == null,
           ),
@@ -213,7 +216,7 @@ class _KPICards extends StatelessWidget {
         const SizedBox(width: AppSpacing.md),
         Expanded(
           child: _KPICard(
-            title: 'Receipts',
+            title: t.receiptsMetricLabel,
             value: receiptsValue,
             isLoading: isLoading && data == null,
           ),
@@ -288,6 +291,7 @@ class _MonthlyChart extends StatelessWidget {
       symbol: 'PLN ',
       decimalDigits: 2,
     );
+    final t = AppLocalizations.of(context)!;
 
     return Card(
       child: Padding(
@@ -296,7 +300,7 @@ class _MonthlyChart extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Monthly spend',
+              t.monthlySpend,
               style: AppTextStyles.titleMedium.copyWith(
                 color: AppColors.textPrimary,
               ),
@@ -446,6 +450,7 @@ class _TopCategoriesSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return overview.when(
       data: (data) {
         final hasSpending =
@@ -456,7 +461,7 @@ class _TopCategoriesSection extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.all(AppSpacing.md),
               child: Text(
-                'No categorized spending for this month yet',
+                t.noCategorizedSpending,
                 style: AppTextStyles.bodyMedium.copyWith(
                   color: AppColors.textSecondary,
                 ),
@@ -490,7 +495,9 @@ class _TopCategoriesSection extends StatelessWidget {
                 ),
                 const SizedBox(height: AppSpacing.sm),
                 Text(
-                  'Total — ${currencyFormat.format(data.total)}',
+                  t.totalWithAmount(
+                    currencyFormat.format(data.total),
+                  ),
                   style: AppTextStyles.labelSmall.copyWith(
                     color: AppColors.textSecondary,
                   ),
@@ -505,7 +512,7 @@ class _TopCategoriesSection extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.md),
           child: Text(
-            'Unable to load categories',
+            t.unableToLoadCategories,
             style: AppTextStyles.bodyMedium.copyWith(
               color: AppColors.error,
             ),
@@ -578,6 +585,7 @@ class _QuickInsights extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return overview.when(
       data: (data) {
         final currencyFormat = NumberFormat.currency(
@@ -588,18 +596,22 @@ class _QuickInsights extends StatelessWidget {
 
         final ReceiptRow? maxReceipt = data.maxReceipt;
         final maxReceiptSubtitle = maxReceipt == null
-            ? 'No receipts this month'
-            : '${maxReceipt.merchantName}, ${DateFormat('yyyy-MM-dd HH:mm').format(maxReceipt.purchaseTimestamp)}';
+            ? t.noReceiptsThisMonth
+            : t.receiptMerchantAndDate(
+                maxReceipt.merchantName,
+                DateFormat('yyyy-MM-dd HH:mm')
+                    .format(maxReceipt.purchaseTimestamp),
+              );
 
-        final receiptsLabel = data.receiptsCount == 1
-            ? '1 receipt'
-            : '${data.receiptsCount} receipts';
+        final receiptsLabel = t.receiptCount(data.receiptsCount);
 
         return Row(
           children: [
             Expanded(
               child: _InsightCard(
-                title: 'Max receipt — ${monthFormat.format(data.month)}',
+                title: t.maxReceiptForMonth(
+                  monthFormat.format(data.month),
+                ),
                 value: maxReceipt == null
                     ? '—'
                     : currencyFormat.format(maxReceipt.totalGross),
@@ -609,7 +621,9 @@ class _QuickInsights extends StatelessWidget {
             const SizedBox(width: AppSpacing.md),
             Expanded(
               child: _InsightCard(
-                title: 'Total — ${monthFormat.format(data.month)}',
+                title: t.totalForMonth(
+                  monthFormat.format(data.month),
+                ),
                 value: currencyFormat.format(data.total),
                 subtitle: receiptsLabel,
               ),
@@ -619,20 +633,20 @@ class _QuickInsights extends StatelessWidget {
       },
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, _) => Row(
-        children: const [
+        children: [
           Expanded(
             child: _InsightCard(
-              title: 'Max receipt',
+              title: t.maxReceipt,
               value: '—',
-              subtitle: 'Unable to load data',
+              subtitle: t.unableToLoadData,
             ),
           ),
-          SizedBox(width: AppSpacing.md),
+          const SizedBox(width: AppSpacing.md),
           Expanded(
             child: _InsightCard(
-              title: 'Total',
+              title: t.totalLabel,
               value: '—',
-              subtitle: 'Unable to load data',
+              subtitle: t.unableToLoadData,
             ),
           ),
         ],
@@ -694,6 +708,7 @@ class _DashboardEmptyState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.lg),
@@ -707,14 +722,14 @@ class _DashboardEmptyState extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.md),
             Text(
-              'No receipts yet',
+              t.dashboardEmptyTitle,
               style: AppTextStyles.titleMedium.copyWith(
                 color: AppColors.textPrimary,
               ),
             ),
             const SizedBox(height: AppSpacing.sm),
             Text(
-              'Import your first receipt to see analytics',
+              t.dashboardEmptyMessage,
               textAlign: TextAlign.center,
               style: AppTextStyles.bodyMedium.copyWith(
                 color: AppColors.textSecondary,
@@ -723,7 +738,7 @@ class _DashboardEmptyState extends StatelessWidget {
             const SizedBox(height: AppSpacing.lg),
             ElevatedButton(
               onPressed: onImport,
-              child: const Text('Import PDF'),
+              child: Text(t.importPdf),
             ),
           ],
         ),
@@ -739,6 +754,7 @@ class _DashboardErrorState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.lg),
@@ -752,7 +768,7 @@ class _DashboardErrorState extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.md),
             Text(
-              'Something went wrong',
+              t.dashboardErrorMessage,
               style: AppTextStyles.titleMedium.copyWith(
                 color: AppColors.textPrimary,
               ),

--- a/lib/features/import/import_view.dart
+++ b/lib/features/import/import_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:receipts/l10n/app_localizations.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/domain/models/import_result.dart';
@@ -11,6 +12,7 @@ class ImportView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final t = AppLocalizations.of(context)!;
     final importState = ref.watch(importControllerProvider);
     final controller = ref.watch(importControllerProvider.notifier);
     final entries = controller.historyEntries;
@@ -26,7 +28,7 @@ class ImportView extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Import receipts'),
+        title: Text(t.importReceiptsTitle),
       ),
       body: Padding(
         padding: const EdgeInsets.all(AppSpacing.md),
@@ -37,7 +39,7 @@ class ImportView extends ConsumerWidget {
               key: const ValueKey('import_button'),
               onPressed: () => _importReceipts(context, ref),
               icon: const Icon(Icons.upload_file),
-              label: const Text('Import receipts (PDF or JSON)'),
+              label: Text(t.importReceiptsButton),
               style: ElevatedButton.styleFrom(
                 padding: const EdgeInsets.all(AppSpacing.md),
               ),
@@ -56,7 +58,7 @@ class ImportView extends ConsumerWidget {
             ),
             const SizedBox(height: AppSpacing.md),
             Text(
-              'Files are copied to app storage for reliable access.',
+              t.filesCopiedInfo,
               style: AppTextStyles.labelSmall.copyWith(
                 color: AppColors.textSecondary,
               ),
@@ -80,8 +82,9 @@ class ImportView extends ConsumerWidget {
       await ref.read(importControllerProvider.notifier).importUris(uris);
     } catch (error) {
       if (!context.mounted) return;
+      final t = AppLocalizations.of(context)!;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Import failed: $error')),
+        SnackBar(content: Text(t.importFailed('$error'))),
       );
     }
   }
@@ -106,6 +109,7 @@ class _EmptyState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -117,14 +121,14 @@ class _EmptyState extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.md),
           Text(
-            'No imports yet',
+            t.noImportsYet,
             style: AppTextStyles.titleMedium.copyWith(
               color: AppColors.textPrimary,
             ),
           ),
           const SizedBox(height: AppSpacing.sm),
           Text(
-            'Import your first receipt (PDF or JSON)',
+            t.importFirstReceiptPrompt,
             style: AppTextStyles.bodyMedium.copyWith(
               color: AppColors.textSecondary,
             ),
@@ -160,9 +164,10 @@ class _ImportHistoryItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fileName = _resolveFileName(result.sourceUri);
-    final subtitle = _buildSubtitle(entry.timestamp, result.message);
-    final badgeStyle = _badgeStyle(result.status);
+    final t = AppLocalizations.of(context)!;
+    final fileName = _resolveFileName(t, result.sourceUri);
+    final subtitle = _buildSubtitle(t, entry.timestamp, result.message);
+    final badgeStyle = _badgeStyle(result.status, t);
 
     return Card(
       child: ListTile(
@@ -187,32 +192,36 @@ class _ImportHistoryItem extends StatelessWidget {
     );
   }
 
-  String _buildSubtitle(DateTime timestamp, String? message) {
-    final parts = <String>[_formatTimestamp(timestamp)];
+  String _buildSubtitle(
+    AppLocalizations t,
+    DateTime timestamp,
+    String? message,
+  ) {
+    final parts = <String>[_formatTimestamp(t, timestamp)];
     if (message != null && message.isNotEmpty) {
       parts.add(message);
     }
     return parts.join(' • ');
   }
 
-  _BadgeStyle _badgeStyle(ImportStatus status) {
+  _BadgeStyle _badgeStyle(ImportStatus status, AppLocalizations t) {
     switch (status) {
       case ImportStatus.success:
-        return const _BadgeStyle(label: 'Success', color: AppColors.success);
+        return _BadgeStyle(label: t.importStatusSuccess, color: AppColors.success);
       case ImportStatus.duplicate:
-        return const _BadgeStyle(
-          label: 'Duplicate',
+        return _BadgeStyle(
+          label: t.importStatusDuplicate,
           color: AppColors.warning,
           outlined: true,
         );
       case ImportStatus.error:
-        return const _BadgeStyle(label: 'Error', color: AppColors.error);
+        return _BadgeStyle(label: t.importStatusError, color: AppColors.error);
     }
   }
 
-  String _resolveFileName(String? sourceUri) {
+  String _resolveFileName(AppLocalizations t, String? sourceUri) {
     if (sourceUri == null || sourceUri.isEmpty) {
-      return 'Unknown file';
+      return t.unknownFile;
     }
 
     try {
@@ -227,18 +236,21 @@ class _ImportHistoryItem extends StatelessWidget {
     }
   }
 
-  String _formatTimestamp(DateTime timestamp) {
+  String _formatTimestamp(AppLocalizations t, DateTime timestamp) {
     final now = DateTime.now();
     final difference = now.difference(timestamp);
 
     if (difference.inMinutes < 1) {
-      return 'Just now';
+      return t.justNow;
     } else if (difference.inHours < 1) {
-      return '${difference.inMinutes}m ago';
+      final minutes = difference.inMinutes;
+      return t.minutesAgo(minutes);
     } else if (difference.inDays < 1) {
-      return '${difference.inHours}h ago';
+      final hours = difference.inHours;
+      return t.hoursAgo(hours);
     } else {
-      return '${difference.inDays}d ago';
+      final days = difference.inDays;
+      return t.daysAgo(days);
     }
   }
 }

--- a/lib/features/month/month_view.dart
+++ b/lib/features/month/month_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:receipts/l10n/app_localizations.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/domain/models/month_overview.dart';
@@ -14,6 +15,7 @@ class MonthView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final t = AppLocalizations.of(context)!;
     final selectedMonth = ref.watch(selectedMonthProvider);
     final monthlyTotalsAsync = ref.watch(monthlyTotalsProvider);
     final monthOverviewAsync = ref.watch(monthOverviewProvider(selectedMonth));
@@ -41,7 +43,7 @@ class MonthView extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Month overview'),
+        title: Text(t.monthOverviewTitle),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(AppSpacing.md),
@@ -54,7 +56,9 @@ class MonthView extends ConsumerWidget {
             ),
             const SizedBox(height: AppSpacing.lg),
             Text(
-              'Spending by category — ${monthFormat.format(selectedMonth)}',
+              t.spendingByCategoryForMonth(
+                monthFormat.format(selectedMonth),
+              ),
               style: AppTextStyles.titleMedium.copyWith(
                 color: AppColors.textPrimary,
               ),
@@ -66,14 +70,16 @@ class MonthView extends ConsumerWidget {
               children: [
                 Expanded(
                   child: _MetricCard(
-                    title: 'Total — ${monthFormat.format(selectedMonth)}',
+                    title: t.totalForMonth(
+                      monthFormat.format(selectedMonth),
+                    ),
                     value: totalValue,
                   ),
                 ),
                 const SizedBox(width: AppSpacing.md),
                 Expanded(
                   child: _MetricCard(
-                    title: 'Receipts',
+                    title: t.receiptsMetricLabel,
                     value: '$receiptsCount',
                   ),
                 ),
@@ -81,7 +87,7 @@ class MonthView extends ConsumerWidget {
             ),
             const SizedBox(height: AppSpacing.lg),
             Text(
-              'Recent receipts',
+              t.recentReceipts,
               style: AppTextStyles.titleMedium.copyWith(
                 color: AppColors.textPrimary,
               ),
@@ -94,7 +100,7 @@ class MonthView extends ConsumerWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(AppSpacing.md),
                       child: Text(
-                        'No receipts recorded for this month yet',
+                        t.noReceiptsForMonth,
                         style: AppTextStyles.bodyMedium.copyWith(
                           color: AppColors.textSecondary,
                         ),
@@ -118,7 +124,7 @@ class MonthView extends ConsumerWidget {
                 child: Padding(
                   padding: const EdgeInsets.all(AppSpacing.md),
                   child: Text(
-                    'Unable to load receipts: $error',
+                    t.unableToLoadReceipts('$error'),
                     style: AppTextStyles.bodyMedium.copyWith(
                       color: AppColors.error,
                     ),
@@ -131,7 +137,7 @@ class MonthView extends ConsumerWidget {
               alignment: Alignment.center,
               child: TextButton(
                 onPressed: () => context.go('/receipts'),
-                child: Text('Show all receipts ($receiptsCount)'),
+                child: Text(t.showAllReceipts(receiptsCount)),
               ),
             ),
           ],
@@ -249,6 +255,7 @@ class _CategoryBreakdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return overview.when(
       data: (data) {
         final hasSpending =
@@ -259,7 +266,7 @@ class _CategoryBreakdown extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.all(AppSpacing.md),
               child: Text(
-                'No categorized spending for this month yet',
+                t.noCategorizedSpending,
                 style: AppTextStyles.bodyMedium.copyWith(
                   color: AppColors.textSecondary,
                 ),
@@ -293,7 +300,9 @@ class _CategoryBreakdown extends StatelessWidget {
                 ),
                 const SizedBox(height: AppSpacing.sm),
                 Text(
-                  'Total — ${currencyFormat.format(data.total)}',
+                  t.totalWithAmount(
+                    currencyFormat.format(data.total),
+                  ),
                   style: AppTextStyles.labelSmall.copyWith(
                     color: AppColors.textSecondary,
                   ),
@@ -308,7 +317,7 @@ class _CategoryBreakdown extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.md),
           child: Text(
-            'Unable to load categories: $error',
+            t.unableToLoadCategoriesWithError('$error'),
             style: AppTextStyles.bodyMedium.copyWith(
               color: AppColors.error,
             ),

--- a/lib/features/onboarding/onboarding_view.dart
+++ b/lib/features/onboarding/onboarding_view.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:receipts/l10n/app_localizations.dart';
+
 import 'package:receipts/theme.dart';
 
 class OnboardingView extends StatelessWidget {
@@ -7,6 +9,8 @@ class OnboardingView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+
     return Scaffold(
       body: SafeArea(
         child: Padding(
@@ -23,24 +27,23 @@ class OnboardingView extends StatelessWidget {
               ),
               const SizedBox(height: AppSpacing.xl),
               Text(
-                'Local-only processing',
+                t.onboardingTitle,
                 style: AppTextStyles.titleLarge.copyWith(
                   color: AppColors.textPrimary,
                 ),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: AppSpacing.lg),
-              _BulletPoint(text: 'Optimized for PDF receipts (MVP)'),
+              _BulletPoint(text: t.onboardingBulletOptimized),
               const SizedBox(height: AppSpacing.md),
-              _BulletPoint(text: 'All data stays on this device'),
+              _BulletPoint(text: t.onboardingBulletLocalData),
               const SizedBox(height: AppSpacing.md),
-              _BulletPoint(
-                  text: 'Optional crash reports (you can disable any time)'),
+              _BulletPoint(text: t.onboardingBulletCrashReports),
               const Spacer(),
               ElevatedButton(
                 key: const ValueKey('onboarding_get_started'),
                 onPressed: () => context.go('/dashboard'),
-                child: const Text('Get started'),
+                child: Text(t.onboardingGetStarted),
               ),
               const SizedBox(height: AppSpacing.lg),
             ],

--- a/lib/features/receipt_details/receipt_details_view.dart
+++ b/lib/features/receipt_details/receipt_details_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:receipts/l10n/app_localizations.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/domain/models/line_item.dart';
@@ -32,7 +33,7 @@ class _LoadingState extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Receipt'),
+        title: Text(AppLocalizations.of(context)!.receiptTitle),
       ),
       body: const Center(child: CircularProgressIndicator()),
     );
@@ -46,8 +47,9 @@ class _ErrorState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: const Text('Receipt')),
+      appBar: AppBar(title: Text(t.receiptTitle)),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -59,7 +61,7 @@ class _ErrorState extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.md),
             Text(
-              'Receipt not found',
+              t.receiptNotFound,
               style: AppTextStyles.titleMedium.copyWith(
                 color: AppColors.textPrimary,
               ),
@@ -75,7 +77,7 @@ class _ErrorState extends StatelessWidget {
             const SizedBox(height: AppSpacing.lg),
             ElevatedButton(
               onPressed: () => GoRouter.of(context).go('/receipts'),
-              child: const Text('Back to receipts'),
+              child: Text(t.backToReceipts),
             ),
           ],
         ),
@@ -91,9 +93,10 @@ class _ReceiptDetailsContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Receipt'),
+        title: Text(t.receiptTitle),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () => context.pop(),
@@ -184,7 +187,7 @@ class _ItemsTable extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.md),
           child: Text(
-            'No line items were recorded for this receipt',
+            AppLocalizations.of(context)!.noLineItems,
             style: AppTextStyles.bodyMedium.copyWith(
               color: AppColors.textSecondary,
             ),
@@ -216,12 +219,13 @@ class _ItemsTable extends StatelessWidget {
 class _TableHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Row(
       children: [
         Expanded(
           flex: 3,
           child: Text(
-            'Item',
+            t.itemHeader,
             style: AppTextStyles.labelSmall.copyWith(
               color: AppColors.textSecondary,
               fontWeight: FontWeight.w600,
@@ -231,7 +235,7 @@ class _TableHeader extends StatelessWidget {
         Expanded(
           flex: 2,
           child: Text(
-            'Qty × Price',
+            t.quantityPriceHeader,
             style: AppTextStyles.labelSmall.copyWith(
               color: AppColors.textSecondary,
               fontWeight: FontWeight.w600,
@@ -241,7 +245,7 @@ class _TableHeader extends StatelessWidget {
         ),
         Expanded(
           child: Text(
-            'VAT',
+            t.vatHeader,
             style: AppTextStyles.labelSmall.copyWith(
               color: AppColors.textSecondary,
               fontWeight: FontWeight.w600,
@@ -251,7 +255,7 @@ class _TableHeader extends StatelessWidget {
         ),
         Expanded(
           child: Text(
-            'Total',
+            t.totalHeader,
             style: AppTextStyles.labelSmall.copyWith(
               color: AppColors.textSecondary,
               fontWeight: FontWeight.w600,
@@ -359,7 +363,7 @@ class _VATSummary extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              'VAT total:',
+              AppLocalizations.of(context)!.vatTotalLabel,
               style: AppTextStyles.bodyMedium.copyWith(
                 color: AppColors.textSecondary,
               ),
@@ -383,17 +387,18 @@ class _ActionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Row(
       children: [
         Expanded(
           child: ElevatedButton.icon(
             onPressed: () {
               ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('PDF opening not implemented yet')),
+                SnackBar(content: Text(t.pdfOpenNotImplemented)),
               );
             },
             icon: const Icon(Icons.picture_as_pdf),
-            label: const Text('Open PDF'),
+            label: Text(t.openPdf),
           ),
         ),
         const SizedBox(width: AppSpacing.md),
@@ -401,11 +406,11 @@ class _ActionButtons extends StatelessWidget {
           child: TextButton.icon(
             onPressed: () {
               ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Re-categorization not implemented yet')),
+                SnackBar(content: Text(t.recategorizationNotImplemented)),
               );
             },
             icon: const Icon(Icons.category),
-            label: const Text('Re-categorize'),
+            label: Text(t.recategorize),
           ),
         ),
       ],

--- a/lib/features/receipts/receipts_view.dart
+++ b/lib/features/receipts/receipts_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:receipts/l10n/app_localizations.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/domain/models/monthly_total.dart';
@@ -13,6 +14,7 @@ class ReceiptsView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final t = AppLocalizations.of(context)!;
     final filteredReceiptsAsync = ref.watch(filteredReceiptsProvider);
     final searchQuery = ref.watch(receiptsSearchQueryProvider);
     final selectedMonth = ref.watch(receiptsFilterMonthProvider);
@@ -26,7 +28,7 @@ class ReceiptsView extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Receipts'),
+        title: Text(t.receiptsTitle),
       ),
       body: Column(
         children: [
@@ -50,7 +52,7 @@ class ReceiptsView extends ConsumerWidget {
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (error, _) => Center(
                 child: Text(
-                  'Unable to load receipts: $error',
+                  t.unableToLoadReceipts('$error'),
                   style: AppTextStyles.bodyMedium.copyWith(
                     color: AppColors.error,
                   ),
@@ -129,16 +131,17 @@ class _SearchAndFiltersState extends ConsumerState<_SearchAndFilters> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Container(
       padding: const EdgeInsets.all(AppSpacing.md),
       child: Column(
         children: [
           TextField(
             controller: _controller,
-            decoration: const InputDecoration(
-              hintText: 'Search by merchant or date',
-              prefixIcon: Icon(Icons.search),
-              border: OutlineInputBorder(),
+            decoration: InputDecoration(
+              hintText: t.searchHint,
+              prefixIcon: const Icon(Icons.search),
+              border: const OutlineInputBorder(),
             ),
             onChanged: widget.onSearchChanged,
           ),
@@ -150,14 +153,14 @@ class _SearchAndFiltersState extends ConsumerState<_SearchAndFilters> {
               Widget buildMonthDropdown({bool expandWidth = false}) {
                 final dropdown = DropdownButtonFormField<DateTime?>(
                   value: widget.selectedMonth,
-                  decoration: const InputDecoration(
-                    labelText: 'Month',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: t.monthFilterLabel,
+                    border: const OutlineInputBorder(),
                   ),
                   items: [
-                    const DropdownMenuItem(
+                    DropdownMenuItem(
                       value: null,
-                      child: Text('All months'),
+                      child: Text(t.allMonths),
                     ),
                     ...widget.monthOptions.map(
                       (month) => DropdownMenuItem(
@@ -181,7 +184,10 @@ class _SearchAndFiltersState extends ConsumerState<_SearchAndFilters> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'Total range: PLN ${widget.amountRange.start.round()} - ${widget.amountRange.end.round()}',
+                      t.totalRangeLabel(
+                        widget.amountRange.start.round(),
+                        widget.amountRange.end.round(),
+                      ),
                       style: AppTextStyles.labelSmall,
                     ),
                     RangeSlider(
@@ -226,6 +232,7 @@ class _EmptyState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -237,14 +244,14 @@ class _EmptyState extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.md),
           Text(
-            'No receipts found',
+            t.noReceiptsFound,
             style: AppTextStyles.titleMedium.copyWith(
               color: AppColors.textPrimary,
             ),
           ),
           const SizedBox(height: AppSpacing.sm),
           Text(
-            'Try adjusting your search or filters',
+            t.adjustSearchFilters,
             style: AppTextStyles.bodyMedium.copyWith(
               color: AppColors.textSecondary,
             ),

--- a/lib/features/settings/language_page.dart
+++ b/lib/features/settings/language_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:receipts/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:receipts/core/localization/locale_controller.dart';

--- a/lib/features/settings/settings_view.dart
+++ b/lib/features/settings/settings_view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:receipts/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -52,17 +52,17 @@ class SettingsView extends ConsumerWidget {
           ),
           const SizedBox(height: AppSpacing.lg),
           _SettingsSection(
-            title: 'Crash reports',
+            title: t.crashReportsTitle,
             children: [
               SwitchListTile(
                 title: Text(
-                  'Enable Sentry crash reports',
+                  t.enableSentryCrashReports,
                   style: AppTextStyles.bodyLarge.copyWith(
                     color: AppColors.textPrimary,
                   ),
                 ),
                 subtitle: Text(
-                  'No personal data is sent. Changes take effect immediately.',
+                  t.crashReportsDescription,
                   style: AppTextStyles.bodyMedium.copyWith(
                     color: AppColors.textSecondary,
                   ),
@@ -74,8 +74,8 @@ class SettingsView extends ConsumerWidget {
                       .setEnabled(value);
 
                   final message = value
-                      ? 'Crash reporting enabled'
-                      : 'Crash reporting disabled';
+                      ? t.crashReportingEnabled
+                      : t.crashReportingDisabled;
 
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
@@ -89,18 +89,18 @@ class SettingsView extends ConsumerWidget {
           ),
           const SizedBox(height: AppSpacing.lg),
           _SettingsSection(
-            title: 'About',
+            title: t.aboutSectionTitle,
             children: [
               ListTile(
                 title: Text(
-                  'Receipts — MVP',
+                  t.aboutAppTitle,
                   style: AppTextStyles.bodyLarge.copyWith(
                     color: AppColors.textPrimary,
                     fontWeight: FontWeight.w600,
                   ),
                 ),
                 subtitle: Text(
-                  'Receipts app (MVP). All processing on device.',
+                  t.aboutAppDescription,
                   style: AppTextStyles.bodyMedium.copyWith(
                     color: AppColors.textSecondary,
                   ),
@@ -109,7 +109,7 @@ class SettingsView extends ConsumerWidget {
               ),
               ListTile(
                 title: Text(
-                  'Version',
+                  t.versionLabel,
                   style: AppTextStyles.bodyLarge.copyWith(
                     color: AppColors.textPrimary,
                   ),
@@ -124,13 +124,13 @@ class SettingsView extends ConsumerWidget {
               ),
               ListTile(
                 title: Text(
-                  'Data storage',
+                  t.dataStorageTitle,
                   style: AppTextStyles.bodyLarge.copyWith(
                     color: AppColors.textPrimary,
                   ),
                 ),
                 subtitle: Text(
-                  'All receipts and data are stored locally on this device',
+                  t.dataStorageDescription,
                   style: AppTextStyles.bodyMedium.copyWith(
                     color: AppColors.textSecondary,
                   ),
@@ -154,7 +154,7 @@ class SettingsView extends ConsumerWidget {
                           ),
                           const SizedBox(width: AppSpacing.sm),
                           Text(
-                            'Privacy First',
+                            t.privacyFirstTitle,
                             style: AppTextStyles.bodyLarge.copyWith(
                               color: AppColors.primary,
                               fontWeight: FontWeight.w600,
@@ -164,7 +164,7 @@ class SettingsView extends ConsumerWidget {
                       ),
                       const SizedBox(height: AppSpacing.sm),
                       Text(
-                        'Your receipts are processed entirely on your device. No data is sent to external servers except for optional crash reports.',
+                        t.privacyFirstDescription,
                         style: AppTextStyles.bodyMedium.copyWith(
                           color: AppColors.textSecondary,
                         ),
@@ -177,17 +177,17 @@ class SettingsView extends ConsumerWidget {
           ),
           const SizedBox(height: AppSpacing.lg),
           _SettingsSection(
-            title: 'Debug',
+            title: t.debugSectionTitle,
             children: [
               ListTile(
                 title: Text(
-                  'Clear all data',
+                  t.clearAllData,
                   style: AppTextStyles.bodyLarge.copyWith(
                     color: AppColors.error,
                   ),
                 ),
                 subtitle: Text(
-                  'Remove all receipts and reset the app',
+                  t.clearAllDataDescription,
                   style: AppTextStyles.bodyMedium.copyWith(
                     color: AppColors.textSecondary,
                   ),
@@ -203,13 +203,12 @@ class SettingsView extends ConsumerWidget {
   }
 
   void _showClearDataDialog(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Clear all data?'),
-        content: const Text(
-          'This will permanently delete all receipts and data. This action cannot be undone.',
-        ),
+        title: Text(t.clearAllDataDialogTitle),
+        content: Text(t.clearAllDataDialogMessage),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
@@ -219,13 +218,11 @@ class SettingsView extends ConsumerWidget {
             onPressed: () {
               Navigator.of(context).pop();
               ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('Data clearing not implemented yet'),
-                ),
+                SnackBar(content: Text(t.clearDataNotImplemented)),
               );
             },
             style: TextButton.styleFrom(foregroundColor: AppColors.error),
-            child: const Text('Clear'),
+            child: Text(t.clearAction),
           ),
         ],
       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -12,5 +12,179 @@
   "openInBrowser": "Open in browser",
   "couldNotOpenLink": "Could not open link",
   "ok": "OK",
-  "cancel": "Cancel"
+  "cancel": "Cancel",
+  "crashReportsTitle": "Crash reports",
+  "enableSentryCrashReports": "Enable Sentry crash reports",
+  "crashReportsDescription": "No personal data is sent. Changes take effect immediately.",
+  "crashReportingEnabled": "Crash reporting enabled",
+  "crashReportingDisabled": "Crash reporting disabled",
+  "aboutSectionTitle": "About",
+  "aboutAppTitle": "Receipts — MVP",
+  "aboutAppDescription": "Receipts app (MVP). All processing on device.",
+  "versionLabel": "Version",
+  "dataStorageTitle": "Data storage",
+  "dataStorageDescription": "All receipts and data are stored locally on this device",
+  "privacyFirstTitle": "Privacy First",
+  "privacyFirstDescription": "Your receipts are processed entirely on your device. No data is sent to external servers except for optional crash reports.",
+  "debugSectionTitle": "Debug",
+  "clearAllData": "Clear all data",
+  "clearAllDataDescription": "Remove all receipts and reset the app",
+  "clearAllDataDialogTitle": "Clear all data?",
+  "clearAllDataDialogMessage": "This will permanently delete all receipts and data. This action cannot be undone.",
+  "clearDataNotImplemented": "Data clearing not implemented yet",
+  "clearAction": "Clear",
+  "onboardingTitle": "Local-only processing",
+  "onboardingBulletOptimized": "Optimized for PDF receipts (MVP)",
+  "onboardingBulletLocalData": "All data stays on this device",
+  "onboardingBulletCrashReports": "Optional crash reports (you can disable any time)",
+  "onboardingGetStarted": "Get started",
+  "monthOverviewTitle": "Month overview",
+  "spendingByCategoryForMonth": "Spending by category — {month}",
+  "@spendingByCategoryForMonth": {
+    "placeholders": {
+      "month": {}
+    }
+  },
+  "totalForMonth": "Total — {month}",
+  "@totalForMonth": {
+    "placeholders": {
+      "month": {}
+    }
+  },
+  "totalLast30Days": "Total (30d)",
+  "averageReceipt": "Average receipt",
+  "receiptsMetricLabel": "Receipts",
+  "recentReceipts": "Recent receipts",
+  "noReceiptsForMonth": "No receipts recorded for this month yet",
+  "unableToLoadReceipts": "Unable to load receipts: {error}",
+  "@unableToLoadReceipts": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "showAllReceipts": "Show all receipts ({count})",
+  "@showAllReceipts": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "noCategorizedSpending": "No categorized spending for this month yet",
+  "totalWithAmount": "Total — {amount}",
+  "@totalWithAmount": {
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "unableToLoadCategoriesWithError": "Unable to load categories: {error}",
+  "@unableToLoadCategoriesWithError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "unableToLoadCategories": "Unable to load categories",
+  "importReceiptsTitle": "Import receipts",
+  "importReceiptsButton": "Import receipts (PDF or JSON)",
+  "filesCopiedInfo": "Files are copied to app storage for reliable access.",
+  "importFailed": "Import failed: {error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "noImportsYet": "No imports yet",
+  "importFirstReceiptPrompt": "Import your first receipt (PDF or JSON)",
+  "importStatusSuccess": "Success",
+  "importStatusDuplicate": "Duplicate",
+  "importStatusError": "Error",
+  "unknownFile": "Unknown file",
+  "justNow": "Just now",
+  "minutesAgo": "{count, plural, one {{count} min ago} other {{count} min ago}}",
+  "@minutesAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "hoursAgo": "{count, plural, one {{count} h ago} other {{count} h ago}}",
+  "@hoursAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "daysAgo": "{count, plural, one {{count} d ago} other {{count} d ago}}",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "receiptsTitle": "Receipts",
+  "searchHint": "Search by merchant or date",
+  "monthFilterLabel": "Month",
+  "allMonths": "All months",
+  "totalRangeLabel": "Total range: PLN {start} - PLN {end}",
+  "@totalRangeLabel": {
+    "placeholders": {
+      "start": {
+        "type": "int"
+      },
+      "end": {
+        "type": "int"
+      }
+    }
+  },
+  "noReceiptsFound": "No receipts found",
+  "adjustSearchFilters": "Try adjusting your search or filters",
+  "receiptTitle": "Receipt",
+  "receiptNotFound": "Receipt not found",
+  "backToReceipts": "Back to receipts",
+  "noLineItems": "No line items were recorded for this receipt",
+  "itemHeader": "Item",
+  "quantityPriceHeader": "Qty × Price",
+  "vatHeader": "VAT",
+  "totalHeader": "Total",
+  "vatTotalLabel": "VAT total:",
+  "pdfOpenNotImplemented": "PDF opening not implemented yet",
+  "openPdf": "Open PDF",
+  "recategorizationNotImplemented": "Re-categorization not implemented yet",
+  "recategorize": "Re-categorize",
+  "dashboardTitle": "Spending dashboard",
+  "importPdf": "Import PDF",
+  "selectedMonthLabel": "Selected month",
+  "onDeviceProcessing": "All data is processed on device",
+  "monthlySpend": "Monthly spend",
+  "noReceiptsThisMonth": "No receipts this month",
+  "receiptMerchantAndDate": "{merchant}, {date}",
+  "@receiptMerchantAndDate": {
+    "placeholders": {
+      "merchant": {},
+      "date": {}
+    }
+  },
+  "receiptCount": "{count, plural, one {1 receipt} other {{count} receipts}}",
+  "@receiptCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "maxReceiptForMonth": "Max receipt — {month}",
+  "@maxReceiptForMonth": {
+    "placeholders": {
+      "month": {}
+    }
+  },
+  "maxReceipt": "Max receipt",
+  "totalLabel": "Total",
+  "unableToLoadData": "Unable to load data",
+  "dashboardEmptyTitle": "No receipts yet",
+  "dashboardEmptyMessage": "Import your first receipt to see analytics",
+  "dashboardErrorMessage": "Something went wrong"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,735 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_ru.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations? of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations);
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ru')
+  ];
+
+  /// No description provided for @appTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipts'**
+  String get appTitle;
+
+  /// No description provided for @settingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settingsTitle;
+
+  /// No description provided for @languageTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Language'**
+  String get languageTitle;
+
+  /// No description provided for @chooseLanguage.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose language'**
+  String get chooseLanguage;
+
+  /// No description provided for @english.
+  ///
+  /// In en, this message translates to:
+  /// **'English'**
+  String get english;
+
+  /// No description provided for @russian.
+  ///
+  /// In en, this message translates to:
+  /// **'Russian'**
+  String get russian;
+
+  /// No description provided for @aboutLegal.
+  ///
+  /// In en, this message translates to:
+  /// **'Privacy & Terms'**
+  String get aboutLegal;
+
+  /// No description provided for @privacyPolicy.
+  ///
+  /// In en, this message translates to:
+  /// **'Privacy Policy'**
+  String get privacyPolicy;
+
+  /// No description provided for @termsOfUse.
+  ///
+  /// In en, this message translates to:
+  /// **'Terms of Use'**
+  String get termsOfUse;
+
+  /// No description provided for @openInBrowser.
+  ///
+  /// In en, this message translates to:
+  /// **'Open in browser'**
+  String get openInBrowser;
+
+  /// No description provided for @couldNotOpenLink.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open link'**
+  String get couldNotOpenLink;
+
+  /// No description provided for @ok.
+  ///
+  /// In en, this message translates to:
+  /// **'OK'**
+  String get ok;
+
+  /// No description provided for @cancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get cancel;
+
+  /// No description provided for @crashReportsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Crash reports'**
+  String get crashReportsTitle;
+
+  /// No description provided for @enableSentryCrashReports.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable Sentry crash reports'**
+  String get enableSentryCrashReports;
+
+  /// No description provided for @crashReportsDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'No personal data is sent. Changes take effect immediately.'**
+  String get crashReportsDescription;
+
+  /// No description provided for @crashReportingEnabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Crash reporting enabled'**
+  String get crashReportingEnabled;
+
+  /// No description provided for @crashReportingDisabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Crash reporting disabled'**
+  String get crashReportingDisabled;
+
+  /// No description provided for @aboutSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'About'**
+  String get aboutSectionTitle;
+
+  /// No description provided for @aboutAppTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipts — MVP'**
+  String get aboutAppTitle;
+
+  /// No description provided for @aboutAppDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipts app (MVP). All processing on device.'**
+  String get aboutAppDescription;
+
+  /// No description provided for @versionLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Version'**
+  String get versionLabel;
+
+  /// No description provided for @dataStorageTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Data storage'**
+  String get dataStorageTitle;
+
+  /// No description provided for @dataStorageDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'All receipts and data are stored locally on this device'**
+  String get dataStorageDescription;
+
+  /// No description provided for @privacyFirstTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Privacy First'**
+  String get privacyFirstTitle;
+
+  /// No description provided for @privacyFirstDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Your receipts are processed entirely on your device. No data is sent to external servers except for optional crash reports.'**
+  String get privacyFirstDescription;
+
+  /// No description provided for @debugSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Debug'**
+  String get debugSectionTitle;
+
+  /// No description provided for @clearAllData.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all data'**
+  String get clearAllData;
+
+  /// No description provided for @clearAllDataDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove all receipts and reset the app'**
+  String get clearAllDataDescription;
+
+  /// No description provided for @clearAllDataDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all data?'**
+  String get clearAllDataDialogTitle;
+
+  /// No description provided for @clearAllDataDialogMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This will permanently delete all receipts and data. This action cannot be undone.'**
+  String get clearAllDataDialogMessage;
+
+  /// No description provided for @clearDataNotImplemented.
+  ///
+  /// In en, this message translates to:
+  /// **'Data clearing not implemented yet'**
+  String get clearDataNotImplemented;
+
+  /// No description provided for @clearAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear'**
+  String get clearAction;
+
+  /// No description provided for @onboardingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Local-only processing'**
+  String get onboardingTitle;
+
+  /// No description provided for @onboardingBulletOptimized.
+  ///
+  /// In en, this message translates to:
+  /// **'Optimized for PDF receipts (MVP)'**
+  String get onboardingBulletOptimized;
+
+  /// No description provided for @onboardingBulletLocalData.
+  ///
+  /// In en, this message translates to:
+  /// **'All data stays on this device'**
+  String get onboardingBulletLocalData;
+
+  /// No description provided for @onboardingBulletCrashReports.
+  ///
+  /// In en, this message translates to:
+  /// **'Optional crash reports (you can disable any time)'**
+  String get onboardingBulletCrashReports;
+
+  /// No description provided for @onboardingGetStarted.
+  ///
+  /// In en, this message translates to:
+  /// **'Get started'**
+  String get onboardingGetStarted;
+
+  /// No description provided for @monthOverviewTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Month overview'**
+  String get monthOverviewTitle;
+
+  /// No description provided for @spendingByCategoryForMonth.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending by category — {month}'**
+  String spendingByCategoryForMonth(Object month);
+
+  /// No description provided for @totalForMonth.
+  ///
+  /// In en, this message translates to:
+  /// **'Total — {month}'**
+  String totalForMonth(Object month);
+
+  /// No description provided for @totalLast30Days.
+  ///
+  /// In en, this message translates to:
+  /// **'Total (30d)'**
+  String get totalLast30Days;
+
+  /// No description provided for @averageReceipt.
+  ///
+  /// In en, this message translates to:
+  /// **'Average receipt'**
+  String get averageReceipt;
+
+  /// No description provided for @receiptsMetricLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipts'**
+  String get receiptsMetricLabel;
+
+  /// No description provided for @recentReceipts.
+  ///
+  /// In en, this message translates to:
+  /// **'Recent receipts'**
+  String get recentReceipts;
+
+  /// No description provided for @noReceiptsForMonth.
+  ///
+  /// In en, this message translates to:
+  /// **'No receipts recorded for this month yet'**
+  String get noReceiptsForMonth;
+
+  /// No description provided for @unableToLoadReceipts.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load receipts: {error}'**
+  String unableToLoadReceipts(Object error);
+
+  /// No description provided for @showAllReceipts.
+  ///
+  /// In en, this message translates to:
+  /// **'Show all receipts ({count})'**
+  String showAllReceipts(int count);
+
+  /// No description provided for @noCategorizedSpending.
+  ///
+  /// In en, this message translates to:
+  /// **'No categorized spending for this month yet'**
+  String get noCategorizedSpending;
+
+  /// No description provided for @totalWithAmount.
+  ///
+  /// In en, this message translates to:
+  /// **'Total — {amount}'**
+  String totalWithAmount(Object amount);
+
+  /// No description provided for @unableToLoadCategoriesWithError.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load categories: {error}'**
+  String unableToLoadCategoriesWithError(Object error);
+
+  /// No description provided for @unableToLoadCategories.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load categories'**
+  String get unableToLoadCategories;
+
+  /// No description provided for @importReceiptsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import receipts'**
+  String get importReceiptsTitle;
+
+  /// No description provided for @importReceiptsButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Import receipts (PDF or JSON)'**
+  String get importReceiptsButton;
+
+  /// No description provided for @filesCopiedInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'Files are copied to app storage for reliable access.'**
+  String get filesCopiedInfo;
+
+  /// No description provided for @importFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Import failed: {error}'**
+  String importFailed(Object error);
+
+  /// No description provided for @noImportsYet.
+  ///
+  /// In en, this message translates to:
+  /// **'No imports yet'**
+  String get noImportsYet;
+
+  /// No description provided for @importFirstReceiptPrompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Import your first receipt (PDF or JSON)'**
+  String get importFirstReceiptPrompt;
+
+  /// No description provided for @importStatusSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Success'**
+  String get importStatusSuccess;
+
+  /// No description provided for @importStatusDuplicate.
+  ///
+  /// In en, this message translates to:
+  /// **'Duplicate'**
+  String get importStatusDuplicate;
+
+  /// No description provided for @importStatusError.
+  ///
+  /// In en, this message translates to:
+  /// **'Error'**
+  String get importStatusError;
+
+  /// No description provided for @unknownFile.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown file'**
+  String get unknownFile;
+
+  /// No description provided for @justNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Just now'**
+  String get justNow;
+
+  /// No description provided for @minutesAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one {{count} min ago} other {{count} min ago}}'**
+  String minutesAgo(int count);
+
+  /// No description provided for @hoursAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one {{count} h ago} other {{count} h ago}}'**
+  String hoursAgo(int count);
+
+  /// No description provided for @daysAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one {{count} d ago} other {{count} d ago}}'**
+  String daysAgo(int count);
+
+  /// No description provided for @receiptsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipts'**
+  String get receiptsTitle;
+
+  /// No description provided for @searchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search by merchant or date'**
+  String get searchHint;
+
+  /// No description provided for @monthFilterLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Month'**
+  String get monthFilterLabel;
+
+  /// No description provided for @allMonths.
+  ///
+  /// In en, this message translates to:
+  /// **'All months'**
+  String get allMonths;
+
+  /// No description provided for @totalRangeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Total range: PLN {start} - PLN {end}'**
+  String totalRangeLabel(int start, int end);
+
+  /// No description provided for @noReceiptsFound.
+  ///
+  /// In en, this message translates to:
+  /// **'No receipts found'**
+  String get noReceiptsFound;
+
+  /// No description provided for @adjustSearchFilters.
+  ///
+  /// In en, this message translates to:
+  /// **'Try adjusting your search or filters'**
+  String get adjustSearchFilters;
+
+  /// No description provided for @receiptTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipt'**
+  String get receiptTitle;
+
+  /// No description provided for @receiptNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipt not found'**
+  String get receiptNotFound;
+
+  /// No description provided for @backToReceipts.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to receipts'**
+  String get backToReceipts;
+
+  /// No description provided for @noLineItems.
+  ///
+  /// In en, this message translates to:
+  /// **'No line items were recorded for this receipt'**
+  String get noLineItems;
+
+  /// No description provided for @itemHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Item'**
+  String get itemHeader;
+
+  /// No description provided for @quantityPriceHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Qty × Price'**
+  String get quantityPriceHeader;
+
+  /// No description provided for @vatHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'VAT'**
+  String get vatHeader;
+
+  /// No description provided for @totalHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Total'**
+  String get totalHeader;
+
+  /// No description provided for @vatTotalLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'VAT total:'**
+  String get vatTotalLabel;
+
+  /// No description provided for @pdfOpenNotImplemented.
+  ///
+  /// In en, this message translates to:
+  /// **'PDF opening not implemented yet'**
+  String get pdfOpenNotImplemented;
+
+  /// No description provided for @openPdf.
+  ///
+  /// In en, this message translates to:
+  /// **'Open PDF'**
+  String get openPdf;
+
+  /// No description provided for @recategorizationNotImplemented.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-categorization not implemented yet'**
+  String get recategorizationNotImplemented;
+
+  /// No description provided for @recategorize.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-categorize'**
+  String get recategorize;
+
+  /// No description provided for @dashboardTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Spending dashboard'**
+  String get dashboardTitle;
+
+  /// No description provided for @importPdf.
+  ///
+  /// In en, this message translates to:
+  /// **'Import PDF'**
+  String get importPdf;
+
+  /// No description provided for @selectedMonthLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Selected month'**
+  String get selectedMonthLabel;
+
+  /// No description provided for @onDeviceProcessing.
+  ///
+  /// In en, this message translates to:
+  /// **'All data is processed on device'**
+  String get onDeviceProcessing;
+
+  /// No description provided for @monthlySpend.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly spend'**
+  String get monthlySpend;
+
+  /// No description provided for @noReceiptsThisMonth.
+  ///
+  /// In en, this message translates to:
+  /// **'No receipts this month'**
+  String get noReceiptsThisMonth;
+
+  /// No description provided for @receiptMerchantAndDate.
+  ///
+  /// In en, this message translates to:
+  /// **'{merchant}, {date}'**
+  String receiptMerchantAndDate(Object merchant, Object date);
+
+  /// No description provided for @receiptCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one {1 receipt} other {{count} receipts}}'**
+  String receiptCount(int count);
+
+  /// No description provided for @maxReceiptForMonth.
+  ///
+  /// In en, this message translates to:
+  /// **'Max receipt — {month}'**
+  String maxReceiptForMonth(Object month);
+
+  /// No description provided for @maxReceipt.
+  ///
+  /// In en, this message translates to:
+  /// **'Max receipt'**
+  String get maxReceipt;
+
+  /// No description provided for @totalLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Total'**
+  String get totalLabel;
+
+  /// No description provided for @unableToLoadData.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to load data'**
+  String get unableToLoadData;
+
+  /// No description provided for @dashboardEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No receipts yet'**
+  String get dashboardEmptyTitle;
+
+  /// No description provided for @dashboardEmptyMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Import your first receipt to see analytics'**
+  String get dashboardEmptyMessage;
+
+  /// No description provided for @dashboardErrorMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong'**
+  String get dashboardErrorMessage;
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) => <String>['en', 'ru'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en': return AppLocalizationsEn();
+    case 'ru': return AppLocalizationsRu();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
+}

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,365 @@
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appTitle => 'Receipts';
+
+  @override
+  String get settingsTitle => 'Settings';
+
+  @override
+  String get languageTitle => 'Language';
+
+  @override
+  String get chooseLanguage => 'Choose language';
+
+  @override
+  String get english => 'English';
+
+  @override
+  String get russian => 'Russian';
+
+  @override
+  String get aboutLegal => 'Privacy & Terms';
+
+  @override
+  String get privacyPolicy => 'Privacy Policy';
+
+  @override
+  String get termsOfUse => 'Terms of Use';
+
+  @override
+  String get openInBrowser => 'Open in browser';
+
+  @override
+  String get couldNotOpenLink => 'Could not open link';
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get crashReportsTitle => 'Crash reports';
+
+  @override
+  String get enableSentryCrashReports => 'Enable Sentry crash reports';
+
+  @override
+  String get crashReportsDescription => 'No personal data is sent. Changes take effect immediately.';
+
+  @override
+  String get crashReportingEnabled => 'Crash reporting enabled';
+
+  @override
+  String get crashReportingDisabled => 'Crash reporting disabled';
+
+  @override
+  String get aboutSectionTitle => 'About';
+
+  @override
+  String get aboutAppTitle => 'Receipts — MVP';
+
+  @override
+  String get aboutAppDescription => 'Receipts app (MVP). All processing on device.';
+
+  @override
+  String get versionLabel => 'Version';
+
+  @override
+  String get dataStorageTitle => 'Data storage';
+
+  @override
+  String get dataStorageDescription => 'All receipts and data are stored locally on this device';
+
+  @override
+  String get privacyFirstTitle => 'Privacy First';
+
+  @override
+  String get privacyFirstDescription => 'Your receipts are processed entirely on your device. No data is sent to external servers except for optional crash reports.';
+
+  @override
+  String get debugSectionTitle => 'Debug';
+
+  @override
+  String get clearAllData => 'Clear all data';
+
+  @override
+  String get clearAllDataDescription => 'Remove all receipts and reset the app';
+
+  @override
+  String get clearAllDataDialogTitle => 'Clear all data?';
+
+  @override
+  String get clearAllDataDialogMessage => 'This will permanently delete all receipts and data. This action cannot be undone.';
+
+  @override
+  String get clearDataNotImplemented => 'Data clearing not implemented yet';
+
+  @override
+  String get clearAction => 'Clear';
+
+  @override
+  String get onboardingTitle => 'Local-only processing';
+
+  @override
+  String get onboardingBulletOptimized => 'Optimized for PDF receipts (MVP)';
+
+  @override
+  String get onboardingBulletLocalData => 'All data stays on this device';
+
+  @override
+  String get onboardingBulletCrashReports => 'Optional crash reports (you can disable any time)';
+
+  @override
+  String get onboardingGetStarted => 'Get started';
+
+  @override
+  String get monthOverviewTitle => 'Month overview';
+
+  @override
+  String spendingByCategoryForMonth(Object month) {
+    return 'Spending by category — $month';
+  }
+
+  @override
+  String totalForMonth(Object month) {
+    return 'Total — $month';
+  }
+
+  @override
+  String get totalLast30Days => 'Total (30d)';
+
+  @override
+  String get averageReceipt => 'Average receipt';
+
+  @override
+  String get receiptsMetricLabel => 'Receipts';
+
+  @override
+  String get recentReceipts => 'Recent receipts';
+
+  @override
+  String get noReceiptsForMonth => 'No receipts recorded for this month yet';
+
+  @override
+  String unableToLoadReceipts(Object error) {
+    return 'Unable to load receipts: $error';
+  }
+
+  @override
+  String showAllReceipts(int count) {
+    return 'Show all receipts ($count)';
+  }
+
+  @override
+  String get noCategorizedSpending => 'No categorized spending for this month yet';
+
+  @override
+  String totalWithAmount(Object amount) {
+    return 'Total — $amount';
+  }
+
+  @override
+  String unableToLoadCategoriesWithError(Object error) {
+    return 'Unable to load categories: $error';
+  }
+
+  @override
+  String get unableToLoadCategories => 'Unable to load categories';
+
+  @override
+  String get importReceiptsTitle => 'Import receipts';
+
+  @override
+  String get importReceiptsButton => 'Import receipts (PDF or JSON)';
+
+  @override
+  String get filesCopiedInfo => 'Files are copied to app storage for reliable access.';
+
+  @override
+  String importFailed(Object error) {
+    return 'Import failed: $error';
+  }
+
+  @override
+  String get noImportsYet => 'No imports yet';
+
+  @override
+  String get importFirstReceiptPrompt => 'Import your first receipt (PDF or JSON)';
+
+  @override
+  String get importStatusSuccess => 'Success';
+
+  @override
+  String get importStatusDuplicate => 'Duplicate';
+
+  @override
+  String get importStatusError => 'Error';
+
+  @override
+  String get unknownFile => 'Unknown file';
+
+  @override
+  String get justNow => 'Just now';
+
+  @override
+  String minutesAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count min ago',
+      one: '$count min ago',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String hoursAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count h ago',
+      one: '$count h ago',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String daysAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count d ago',
+      one: '$count d ago',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get receiptsTitle => 'Receipts';
+
+  @override
+  String get searchHint => 'Search by merchant or date';
+
+  @override
+  String get monthFilterLabel => 'Month';
+
+  @override
+  String get allMonths => 'All months';
+
+  @override
+  String totalRangeLabel(int start, int end) {
+    return 'Total range: PLN $start - PLN $end';
+  }
+
+  @override
+  String get noReceiptsFound => 'No receipts found';
+
+  @override
+  String get adjustSearchFilters => 'Try adjusting your search or filters';
+
+  @override
+  String get receiptTitle => 'Receipt';
+
+  @override
+  String get receiptNotFound => 'Receipt not found';
+
+  @override
+  String get backToReceipts => 'Back to receipts';
+
+  @override
+  String get noLineItems => 'No line items were recorded for this receipt';
+
+  @override
+  String get itemHeader => 'Item';
+
+  @override
+  String get quantityPriceHeader => 'Qty × Price';
+
+  @override
+  String get vatHeader => 'VAT';
+
+  @override
+  String get totalHeader => 'Total';
+
+  @override
+  String get vatTotalLabel => 'VAT total:';
+
+  @override
+  String get pdfOpenNotImplemented => 'PDF opening not implemented yet';
+
+  @override
+  String get openPdf => 'Open PDF';
+
+  @override
+  String get recategorizationNotImplemented => 'Re-categorization not implemented yet';
+
+  @override
+  String get recategorize => 'Re-categorize';
+
+  @override
+  String get dashboardTitle => 'Spending dashboard';
+
+  @override
+  String get importPdf => 'Import PDF';
+
+  @override
+  String get selectedMonthLabel => 'Selected month';
+
+  @override
+  String get onDeviceProcessing => 'All data is processed on device';
+
+  @override
+  String get monthlySpend => 'Monthly spend';
+
+  @override
+  String get noReceiptsThisMonth => 'No receipts this month';
+
+  @override
+  String receiptMerchantAndDate(Object merchant, Object date) {
+    return '$merchant, $date';
+  }
+
+  @override
+  String receiptCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count receipts',
+      one: '1 receipt',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String maxReceiptForMonth(Object month) {
+    return 'Max receipt — $month';
+  }
+
+  @override
+  String get maxReceipt => 'Max receipt';
+
+  @override
+  String get totalLabel => 'Total';
+
+  @override
+  String get unableToLoadData => 'Unable to load data';
+
+  @override
+  String get dashboardEmptyTitle => 'No receipts yet';
+
+  @override
+  String get dashboardEmptyMessage => 'Import your first receipt to see analytics';
+
+  @override
+  String get dashboardErrorMessage => 'Something went wrong';
+}

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1,0 +1,373 @@
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Russian (`ru`).
+class AppLocalizationsRu extends AppLocalizations {
+  AppLocalizationsRu([String locale = 'ru']) : super(locale);
+
+  @override
+  String get appTitle => 'Чеки';
+
+  @override
+  String get settingsTitle => 'Настройки';
+
+  @override
+  String get languageTitle => 'Язык';
+
+  @override
+  String get chooseLanguage => 'Выберите язык';
+
+  @override
+  String get english => 'Английский';
+
+  @override
+  String get russian => 'Русский';
+
+  @override
+  String get aboutLegal => 'Политика и условия';
+
+  @override
+  String get privacyPolicy => 'Политика конфиденциальности';
+
+  @override
+  String get termsOfUse => 'Условия использования';
+
+  @override
+  String get openInBrowser => 'Открыть в браузере';
+
+  @override
+  String get couldNotOpenLink => 'Не удалось открыть ссылку';
+
+  @override
+  String get ok => 'ОК';
+
+  @override
+  String get cancel => 'Отмена';
+
+  @override
+  String get crashReportsTitle => 'Отчёты об ошибках';
+
+  @override
+  String get enableSentryCrashReports => 'Включить отправку отчётов об ошибках Sentry';
+
+  @override
+  String get crashReportsDescription => 'Личные данные не отправляются. Изменения применяются сразу.';
+
+  @override
+  String get crashReportingEnabled => 'Отчёты об ошибках включены';
+
+  @override
+  String get crashReportingDisabled => 'Отчёты об ошибках выключены';
+
+  @override
+  String get aboutSectionTitle => 'О приложении';
+
+  @override
+  String get aboutAppTitle => 'Receipts — MVP';
+
+  @override
+  String get aboutAppDescription => 'Приложение Receipts (MVP). Вся обработка на устройстве.';
+
+  @override
+  String get versionLabel => 'Версия';
+
+  @override
+  String get dataStorageTitle => 'Хранение данных';
+
+  @override
+  String get dataStorageDescription => 'Все чеки и данные хранятся локально на этом устройстве';
+
+  @override
+  String get privacyFirstTitle => 'Приватность прежде всего';
+
+  @override
+  String get privacyFirstDescription => 'Ваши чеки обрабатываются полностью на вашем устройстве. Данные не отправляются на внешние серверы, кроме необязательных отчётов об ошибках.';
+
+  @override
+  String get debugSectionTitle => 'Отладка';
+
+  @override
+  String get clearAllData => 'Удалить все данные';
+
+  @override
+  String get clearAllDataDescription => 'Удалить все чеки и сбросить приложение';
+
+  @override
+  String get clearAllDataDialogTitle => 'Удалить все данные?';
+
+  @override
+  String get clearAllDataDialogMessage => 'Это действие навсегда удалит все чеки и данные. Его нельзя отменить.';
+
+  @override
+  String get clearDataNotImplemented => 'Удаление данных пока не реализовано';
+
+  @override
+  String get clearAction => 'Удалить';
+
+  @override
+  String get onboardingTitle => 'Обработка только на устройстве';
+
+  @override
+  String get onboardingBulletOptimized => 'Оптимизировано для PDF-чеков (MVP)';
+
+  @override
+  String get onboardingBulletLocalData => 'Все данные остаются на этом устройстве';
+
+  @override
+  String get onboardingBulletCrashReports => 'Необязательные отчёты об ошибках (их можно отключить в любой момент)';
+
+  @override
+  String get onboardingGetStarted => 'Начать работу';
+
+  @override
+  String get monthOverviewTitle => 'Обзор месяца';
+
+  @override
+  String spendingByCategoryForMonth(Object month) {
+    return 'Расходы по категориям — $month';
+  }
+
+  @override
+  String totalForMonth(Object month) {
+    return 'Итого — $month';
+  }
+
+  @override
+  String get totalLast30Days => 'Итого (30 дн.)';
+
+  @override
+  String get averageReceipt => 'Средний чек';
+
+  @override
+  String get receiptsMetricLabel => 'Чеки';
+
+  @override
+  String get recentReceipts => 'Недавние чеки';
+
+  @override
+  String get noReceiptsForMonth => 'За этот месяц ещё нет чеков';
+
+  @override
+  String unableToLoadReceipts(Object error) {
+    return 'Не удалось загрузить чеки: $error';
+  }
+
+  @override
+  String showAllReceipts(int count) {
+    return 'Показать все чеки ($count)';
+  }
+
+  @override
+  String get noCategorizedSpending => 'За этот месяц ещё нет расходов по категориям';
+
+  @override
+  String totalWithAmount(Object amount) {
+    return 'Итого — $amount';
+  }
+
+  @override
+  String unableToLoadCategoriesWithError(Object error) {
+    return 'Не удалось загрузить категории: $error';
+  }
+
+  @override
+  String get unableToLoadCategories => 'Не удалось загрузить категории';
+
+  @override
+  String get importReceiptsTitle => 'Импорт чеков';
+
+  @override
+  String get importReceiptsButton => 'Импорт чеков (PDF или JSON)';
+
+  @override
+  String get filesCopiedInfo => 'Файлы копируются в память приложения для надёжного доступа.';
+
+  @override
+  String importFailed(Object error) {
+    return 'Не удалось импортировать: $error';
+  }
+
+  @override
+  String get noImportsYet => 'Импортов ещё нет';
+
+  @override
+  String get importFirstReceiptPrompt => 'Импортируйте первый чек (PDF или JSON)';
+
+  @override
+  String get importStatusSuccess => 'Успех';
+
+  @override
+  String get importStatusDuplicate => 'Дубликат';
+
+  @override
+  String get importStatusError => 'Ошибка';
+
+  @override
+  String get unknownFile => 'Неизвестный файл';
+
+  @override
+  String get justNow => 'Только что';
+
+  @override
+  String minutesAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count мин назад',
+      many: '$count мин назад',
+      few: '$count мин назад',
+      one: '$count мин назад',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String hoursAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ч назад',
+      many: '$count ч назад',
+      few: '$count ч назад',
+      one: '$count ч назад',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String daysAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count д назад',
+      many: '$count д назад',
+      few: '$count д назад',
+      one: '$count д назад',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get receiptsTitle => 'Чеки';
+
+  @override
+  String get searchHint => 'Поиск по продавцу или дате';
+
+  @override
+  String get monthFilterLabel => 'Месяц';
+
+  @override
+  String get allMonths => 'Все месяцы';
+
+  @override
+  String totalRangeLabel(int start, int end) {
+    return 'Диапазон суммы: PLN $start – PLN $end';
+  }
+
+  @override
+  String get noReceiptsFound => 'Чеки не найдены';
+
+  @override
+  String get adjustSearchFilters => 'Измените запрос или фильтры';
+
+  @override
+  String get receiptTitle => 'Чек';
+
+  @override
+  String get receiptNotFound => 'Чек не найден';
+
+  @override
+  String get backToReceipts => 'Назад к чекам';
+
+  @override
+  String get noLineItems => 'Для этого чека нет позиций';
+
+  @override
+  String get itemHeader => 'Позиция';
+
+  @override
+  String get quantityPriceHeader => 'Кол-во × Цена';
+
+  @override
+  String get vatHeader => 'НДС';
+
+  @override
+  String get totalHeader => 'Итого';
+
+  @override
+  String get vatTotalLabel => 'НДС всего:';
+
+  @override
+  String get pdfOpenNotImplemented => 'Открытие PDF пока не реализовано';
+
+  @override
+  String get openPdf => 'Открыть PDF';
+
+  @override
+  String get recategorizationNotImplemented => 'Повторная категоризация пока не реализована';
+
+  @override
+  String get recategorize => 'Переклассифицировать';
+
+  @override
+  String get dashboardTitle => 'Панель расходов';
+
+  @override
+  String get importPdf => 'Импорт PDF';
+
+  @override
+  String get selectedMonthLabel => 'Выбранный месяц';
+
+  @override
+  String get onDeviceProcessing => 'Все данные обрабатываются на устройстве';
+
+  @override
+  String get monthlySpend => 'Месячные расходы';
+
+  @override
+  String get noReceiptsThisMonth => 'В этом месяце нет чеков';
+
+  @override
+  String receiptMerchantAndDate(Object merchant, Object date) {
+    return '$merchant, $date';
+  }
+
+  @override
+  String receiptCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count чеков',
+      many: '$count чеков',
+      few: '$count чека',
+      one: '$count чек',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String maxReceiptForMonth(Object month) {
+    return 'Максимальный чек — $month';
+  }
+
+  @override
+  String get maxReceipt => 'Максимальный чек';
+
+  @override
+  String get totalLabel => 'Итого';
+
+  @override
+  String get unableToLoadData => 'Не удалось загрузить данные';
+
+  @override
+  String get dashboardEmptyTitle => 'Чеков ещё нет';
+
+  @override
+  String get dashboardEmptyMessage => 'Импортируйте первый чек, чтобы увидеть аналитику';
+
+  @override
+  String get dashboardErrorMessage => 'Что-то пошло не так';
+}

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,16 +1,190 @@
 {
   "@@locale": "ru",
-  "appTitle": "Receipts",
+  "appTitle": "Чеки",
   "settingsTitle": "Настройки",
   "languageTitle": "Язык",
   "chooseLanguage": "Выберите язык",
   "english": "Английский",
   "russian": "Русский",
-  "aboutLegal": "Политика и Условия",
+  "aboutLegal": "Политика и условия",
   "privacyPolicy": "Политика конфиденциальности",
   "termsOfUse": "Условия использования",
   "openInBrowser": "Открыть в браузере",
   "couldNotOpenLink": "Не удалось открыть ссылку",
   "ok": "ОК",
-  "cancel": "Отмена"
+  "cancel": "Отмена",
+  "crashReportsTitle": "Отчёты об ошибках",
+  "enableSentryCrashReports": "Включить отправку отчётов об ошибках Sentry",
+  "crashReportsDescription": "Личные данные не отправляются. Изменения применяются сразу.",
+  "crashReportingEnabled": "Отчёты об ошибках включены",
+  "crashReportingDisabled": "Отчёты об ошибках выключены",
+  "aboutSectionTitle": "О приложении",
+  "aboutAppTitle": "Receipts — MVP",
+  "aboutAppDescription": "Приложение Receipts (MVP). Вся обработка на устройстве.",
+  "versionLabel": "Версия",
+  "dataStorageTitle": "Хранение данных",
+  "dataStorageDescription": "Все чеки и данные хранятся локально на этом устройстве",
+  "privacyFirstTitle": "Приватность прежде всего",
+  "privacyFirstDescription": "Ваши чеки обрабатываются полностью на вашем устройстве. Данные не отправляются на внешние серверы, кроме необязательных отчётов об ошибках.",
+  "debugSectionTitle": "Отладка",
+  "clearAllData": "Удалить все данные",
+  "clearAllDataDescription": "Удалить все чеки и сбросить приложение",
+  "clearAllDataDialogTitle": "Удалить все данные?",
+  "clearAllDataDialogMessage": "Это действие навсегда удалит все чеки и данные. Его нельзя отменить.",
+  "clearDataNotImplemented": "Удаление данных пока не реализовано",
+  "clearAction": "Удалить",
+  "onboardingTitle": "Обработка только на устройстве",
+  "onboardingBulletOptimized": "Оптимизировано для PDF-чеков (MVP)",
+  "onboardingBulletLocalData": "Все данные остаются на этом устройстве",
+  "onboardingBulletCrashReports": "Необязательные отчёты об ошибках (их можно отключить в любой момент)",
+  "onboardingGetStarted": "Начать работу",
+  "monthOverviewTitle": "Обзор месяца",
+  "spendingByCategoryForMonth": "Расходы по категориям — {month}",
+  "@spendingByCategoryForMonth": {
+    "placeholders": {
+      "month": {}
+    }
+  },
+  "totalForMonth": "Итого — {month}",
+  "@totalForMonth": {
+    "placeholders": {
+      "month": {}
+    }
+  },
+  "totalLast30Days": "Итого (30 дн.)",
+  "averageReceipt": "Средний чек",
+  "receiptsMetricLabel": "Чеки",
+  "recentReceipts": "Недавние чеки",
+  "noReceiptsForMonth": "За этот месяц ещё нет чеков",
+  "unableToLoadReceipts": "Не удалось загрузить чеки: {error}",
+  "@unableToLoadReceipts": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "showAllReceipts": "Показать все чеки ({count})",
+  "@showAllReceipts": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "noCategorizedSpending": "За этот месяц ещё нет расходов по категориям",
+  "totalWithAmount": "Итого — {amount}",
+  "@totalWithAmount": {
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "unableToLoadCategoriesWithError": "Не удалось загрузить категории: {error}",
+  "@unableToLoadCategoriesWithError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "unableToLoadCategories": "Не удалось загрузить категории",
+  "importReceiptsTitle": "Импорт чеков",
+  "importReceiptsButton": "Импорт чеков (PDF или JSON)",
+  "filesCopiedInfo": "Файлы копируются в память приложения для надёжного доступа.",
+  "importFailed": "Не удалось импортировать: {error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "noImportsYet": "Импортов ещё нет",
+  "importFirstReceiptPrompt": "Импортируйте первый чек (PDF или JSON)",
+  "importStatusSuccess": "Успех",
+  "importStatusDuplicate": "Дубликат",
+  "importStatusError": "Ошибка",
+  "unknownFile": "Неизвестный файл",
+  "justNow": "Только что",
+  "minutesAgo": "{count, plural, one {{count} мин назад} few {{count} мин назад} many {{count} мин назад} other {{count} мин назад}}",
+  "@minutesAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "hoursAgo": "{count, plural, one {{count} ч назад} few {{count} ч назад} many {{count} ч назад} other {{count} ч назад}}",
+  "@hoursAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "daysAgo": "{count, plural, one {{count} д назад} few {{count} д назад} many {{count} д назад} other {{count} д назад}}",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "receiptsTitle": "Чеки",
+  "searchHint": "Поиск по продавцу или дате",
+  "monthFilterLabel": "Месяц",
+  "allMonths": "Все месяцы",
+  "totalRangeLabel": "Диапазон суммы: PLN {start} – PLN {end}",
+  "@totalRangeLabel": {
+    "placeholders": {
+      "start": {
+        "type": "int"
+      },
+      "end": {
+        "type": "int"
+      }
+    }
+  },
+  "noReceiptsFound": "Чеки не найдены",
+  "adjustSearchFilters": "Измените запрос или фильтры",
+  "receiptTitle": "Чек",
+  "receiptNotFound": "Чек не найден",
+  "backToReceipts": "Назад к чекам",
+  "noLineItems": "Для этого чека нет позиций",
+  "itemHeader": "Позиция",
+  "quantityPriceHeader": "Кол-во × Цена",
+  "vatHeader": "НДС",
+  "totalHeader": "Итого",
+  "vatTotalLabel": "НДС всего:",
+  "pdfOpenNotImplemented": "Открытие PDF пока не реализовано",
+  "openPdf": "Открыть PDF",
+  "recategorizationNotImplemented": "Повторная категоризация пока не реализована",
+  "recategorize": "Переклассифицировать",
+  "dashboardTitle": "Панель расходов",
+  "importPdf": "Импорт PDF",
+  "selectedMonthLabel": "Выбранный месяц",
+  "onDeviceProcessing": "Все данные обрабатываются на устройстве",
+  "monthlySpend": "Месячные расходы",
+  "noReceiptsThisMonth": "В этом месяце нет чеков",
+  "receiptMerchantAndDate": "{merchant}, {date}",
+  "@receiptMerchantAndDate": {
+    "placeholders": {
+      "merchant": {},
+      "date": {}
+    }
+  },
+  "receiptCount": "{count, plural, one {{count} чек} few {{count} чека} many {{count} чеков} other {{count} чеков}}",
+  "@receiptCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "maxReceiptForMonth": "Максимальный чек — {month}",
+  "@maxReceiptForMonth": {
+    "placeholders": {
+      "month": {}
+    }
+  },
+  "maxReceipt": "Максимальный чек",
+  "totalLabel": "Итого",
+  "unableToLoadData": "Не удалось загрузить данные",
+  "dashboardEmptyTitle": "Чеков ещё нет",
+  "dashboardEmptyMessage": "Импортируйте первый чек, чтобы увидеть аналитику",
+  "dashboardErrorMessage": "Что-то пошло не так"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:receipts/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';


### PR DESCRIPTION
## Summary
- configure Flutter's l10n generation to emit app_localizations.dart inside the package and update imports to use it directly
- expand the English and Russian ARB files with translations for every user-facing string in the app
- replace hard-coded strings across onboarding, settings, import, receipts, receipt details, month, and dashboard views with localized lookups

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68f6ac3c434c832fb06dbd8857ab9d89