### PR TITLE
Enforce HTTPS for optional JP2 AAR download

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,7 +13,11 @@ def jp2Aar = "jp2-android-${jp2Ver}.aar"
 def envUrl = (System.getenv("JP2_AAR_URL") ?: "").trim()
 def envSha = (System.getenv("JP2_AAR_SHA256") ?: "").trim()
 
-def hasJp2 = envUrl.startsWith("http")
+def hasJp2 = envUrl.startsWith("https://")
+
+if (envUrl && !hasJp2) {
+    logger.lifecycle("JP2: ignoring non-HTTPS JP2_AAR_URL. Build will proceed without it.")
+}
 
 if (hasJp2) {
     tasks.register("fetchJp2Aar") {


### PR DESCRIPTION
## Summary
- require the optional JP2 AAR download to use HTTPS before fetching the artifact
- log and skip the download when a non-HTTPS JP2_AAR_URL is provided to avoid insecure transfers

## Testing
- flutter test *(fails: The current Flutter SDK version is 0.0.0-unknown; requires >=3.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_68f926d03970832f8c7f778296ed1bc5