### PR TITLE
Localize bottom navigation labels

### DIFF
--- a/lib/app/main_scaffold.dart
+++ b/lib/app/main_scaffold.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../l10n/app_localizations.dart';
+
 class MainScaffold extends StatelessWidget {
   final Widget child;
 
@@ -14,30 +16,36 @@ class MainScaffold extends StatelessWidget {
         type: BottomNavigationBarType.fixed,
         currentIndex: _getCurrentIndex(context),
         onTap: (index) => _onTap(context, index),
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home, key: ValueKey('nav_home')),
-            label: 'Home',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.upload_file, key: ValueKey('nav_import')),
-            label: 'Import',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.bar_chart, key: ValueKey('nav_stats')),
-            label: 'Stats',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.receipt_long, key: ValueKey('nav_receipts')),
-            label: 'Receipts',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.settings, key: ValueKey('nav_settings')),
-            label: 'Settings',
-          ),
-        ],
+        items: _buildItems(context),
       ),
     );
+  }
+
+  List<BottomNavigationBarItem> _buildItems(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+
+    return [
+      BottomNavigationBarItem(
+        icon: const Icon(Icons.home, key: ValueKey('nav_home')),
+        label: localizations.navHome,
+      ),
+      BottomNavigationBarItem(
+        icon: const Icon(Icons.upload_file, key: ValueKey('nav_import')),
+        label: localizations.navImport,
+      ),
+      BottomNavigationBarItem(
+        icon: const Icon(Icons.bar_chart, key: ValueKey('nav_stats')),
+        label: localizations.navStats,
+      ),
+      BottomNavigationBarItem(
+        icon: const Icon(Icons.receipt_long, key: ValueKey('nav_receipts')),
+        label: localizations.navReceipts,
+      ),
+      BottomNavigationBarItem(
+        icon: const Icon(Icons.settings, key: ValueKey('nav_settings')),
+        label: localizations.navSettings,
+      ),
+    ];
   }
 
   int _getCurrentIndex(BuildContext context) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,11 @@
 {
   "@@locale": "en",
   "appTitle": "Receipts",
+  "navHome": "Home",
+  "navImport": "Import",
+  "navStats": "Stats",
+  "navReceipts": "Receipts",
+  "navSettings": "Settings",
   "settingsTitle": "Settings",
   "languageTitle": "Language",
   "chooseLanguage": "Choose language",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -101,6 +101,36 @@ abstract class AppLocalizations {
   /// **'Receipts'**
   String get appTitle;
 
+  /// No description provided for @navHome.
+  ///
+  /// In en, this message translates to:
+  /// **'Home'**
+  String get navHome;
+
+  /// No description provided for @navImport.
+  ///
+  /// In en, this message translates to:
+  /// **'Import'**
+  String get navImport;
+
+  /// No description provided for @navStats.
+  ///
+  /// In en, this message translates to:
+  /// **'Stats'**
+  String get navStats;
+
+  /// No description provided for @navReceipts.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipts'**
+  String get navReceipts;
+
+  /// No description provided for @navSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get navSettings;
+
   /// No description provided for @settingsTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12,6 +12,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appTitle => 'Receipts';
 
   @override
+  String get navHome => 'Home';
+
+  @override
+  String get navImport => 'Import';
+
+  @override
+  String get navStats => 'Stats';
+
+  @override
+  String get navReceipts => 'Receipts';
+
+  @override
+  String get navSettings => 'Settings';
+
+  @override
   String get settingsTitle => 'Settings';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -12,6 +12,21 @@ class AppLocalizationsRu extends AppLocalizations {
   String get appTitle => 'Чеки';
 
   @override
+  String get navHome => 'Главная';
+
+  @override
+  String get navImport => 'Импорт';
+
+  @override
+  String get navStats => 'Статистика';
+
+  @override
+  String get navReceipts => 'Чеки';
+
+  @override
+  String get navSettings => 'Настройки';
+
+  @override
   String get settingsTitle => 'Настройки';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,6 +1,11 @@
 {
   "@@locale": "ru",
   "appTitle": "Чеки",
+  "navHome": "Главная",
+  "navImport": "Импорт",
+  "navStats": "Статистика",
+  "navReceipts": "Чеки",
+  "navSettings": "Настройки",
   "settingsTitle": "Настройки",
   "languageTitle": "Язык",
   "chooseLanguage": "Выберите язык",


### PR DESCRIPTION
## Summary
- localize the bottom navigation bar labels through AppLocalizations
- add English and Russian translations for the navigation items

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68f947ef74f0832f870cc1712c1d6303