### PR TITLE
Handle e-receipt headers when detecting supported PDFs

### DIFF
--- a/lib/domain/parsing/receipt_parser.dart
+++ b/lib/domain/parsing/receipt_parser.dart
@@ -450,7 +450,7 @@ class ReceiptParser {
     final collapsed = lower.replaceAll(RegExp(r'[\s-]'), '');
 
     return _looksLikeBiedronka(lower, collapsed) ||
-        lower.contains('receipts') ||
+        lower.contains('receipt') ||
         lower.contains('paragon fiskalny') ||
         lower.contains('paragon') ||
         lower.contains('niefiskalny');

--- a/test/receipt_parser_new_format_test.dart
+++ b/test/receipt_parser_new_format_test.dart
@@ -47,6 +47,18 @@ void main() {
     expect(receipt.items, isNotEmpty);
   });
 
+  test('accepts e-receipt header as supported source', () async {
+    final parser = ReceiptParser();
+    final original = await File('assets/sample_receipt.txt').readAsString();
+    final eReceipt =
+        original.replaceFirst('Paragon fiskalny', 'E-Receipt');
+
+    final receipt = parser.parse(eReceipt);
+
+    expect(receipt.merchantId, 'biedronka');
+    expect(receipt.items, isNotEmpty);
+  });
+
   test('parses JSON receipt export', () async {
     final parser = ReceiptParser();
     final text = await File('assets/sample_receipt.json').readAsString();


### PR DESCRIPTION
## Summary
- allow the receipt parser to treat PDFs with e-receipt headers as supported sources
- add a regression test to ensure e-receipt text can be parsed without triggering the unsupported source error

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68fe0390af0c832f9013d5e3b9b44ff5