### PR TITLE
Add localized category labels and month formatting

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -155,11 +155,11 @@ class DatabaseHelper {
       for (final definition in categoryDefinitions) {
         await txn.execute(
           'INSERT OR IGNORE INTO categories (id, name) VALUES (?, ?)',
-          [definition.id, definition.label],
+          [definition.id, definition.fallbackLabel],
         );
         await txn.update(
           'categories',
-          {'name': definition.label},
+          {'name': definition.fallbackLabel},
           where: 'id = ?',
           whereArgs: [definition.id],
         );
@@ -215,7 +215,7 @@ class DatabaseHelper {
     for (final definition in categoryDefinitions) {
       await db.insert('categories', {
         'id': definition.id,
-        'name': definition.label,
+        'name': definition.fallbackLabel,
       });
     }
 

--- a/lib/data/repositories/analytics_repository.dart
+++ b/lib/data/repositories/analytics_repository.dart
@@ -177,7 +177,6 @@ class AnalyticsRepository {
       for (final definition in categoryDefinitions)
         CategoryBreakdown(
           categoryId: definition.id,
-          categoryName: definition.label,
           amount: totalsByCategory[definition.id] ?? 0.0,
         ),
     ];

--- a/lib/domain/category_definitions.dart
+++ b/lib/domain/category_definitions.dart
@@ -10,13 +10,13 @@ class CategoryIds {
 class CategoryDefinition {
   const CategoryDefinition({
     required this.id,
-    required this.label,
+    required this.fallbackLabel,
     this.keywords = const <String>[],
     this.legacyIds = const <String>[],
   });
 
   final String id;
-  final String label;
+  final String fallbackLabel;
   final List<String> keywords;
   final List<String> legacyIds;
 }
@@ -24,7 +24,7 @@ class CategoryDefinition {
 const List<CategoryDefinition> categoryDefinitions = [
   CategoryDefinition(
     id: CategoryIds.freshProduce,
-    label: 'Fresh Produce & Vegetables',
+    fallbackLabel: 'Fresh Produce & Vegetables',
     keywords: const [
       'jabł',
       'jabl',
@@ -60,7 +60,7 @@ const List<CategoryDefinition> categoryDefinitions = [
   ),
   CategoryDefinition(
     id: CategoryIds.dairyEggsBakery,
-    label: 'Dairy, Eggs & Bakery',
+    fallbackLabel: 'Dairy, Eggs & Bakery',
     keywords: const [
       'mleko',
       'milk',
@@ -99,7 +99,7 @@ const List<CategoryDefinition> categoryDefinitions = [
   ),
   CategoryDefinition(
     id: CategoryIds.packagedPantry,
-    label: 'Packaged & Pantry Foods',
+    fallbackLabel: 'Packaged & Pantry Foods',
     keywords: const [
       'makaron',
       'pasta',
@@ -156,7 +156,7 @@ const List<CategoryDefinition> categoryDefinitions = [
   ),
   CategoryDefinition(
     id: CategoryIds.drinksSnacks,
-    label: 'Drinks & Snacks',
+    fallbackLabel: 'Drinks & Snacks',
     keywords: const [
       'napój',
       'napoj',
@@ -194,7 +194,7 @@ const List<CategoryDefinition> categoryDefinitions = [
   ),
   CategoryDefinition(
     id: CategoryIds.householdGoods,
-    label: 'Household Goods',
+    fallbackLabel: 'Household Goods',
     keywords: const [
       'papier',
       'deterg',
@@ -231,7 +231,7 @@ const List<CategoryDefinition> categoryDefinitions = [
   ),
   CategoryDefinition(
     id: CategoryIds.misc,
-    label: 'Miscellaneous / Other',
+    fallbackLabel: 'Miscellaneous / Other',
     legacyIds: const ['other'],
   ),
 ];

--- a/lib/domain/models/month_overview.dart
+++ b/lib/domain/models/month_overview.dart
@@ -28,12 +28,10 @@ class MonthOverview {
 
 class CategoryBreakdown {
   final String categoryId;
-  final String categoryName;
   final double amount;
 
   const CategoryBreakdown({
     required this.categoryId,
-    required this.categoryName,
     required this.amount,
   });
 }

--- a/lib/features/dashboard/dashboard_view.dart
+++ b/lib/features/dashboard/dashboard_view.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:receipts/l10n/app_localizations.dart';
+import 'package:receipts/l10n/app_localizations_extensions.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/domain/models/dashboard_kpis.dart';
@@ -29,8 +30,6 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
     final monthlyTotalsAsync = ref.watch(monthlyTotalsProvider);
     final monthOverviewAsync = ref.watch(monthOverviewProvider(selectedMonth));
     final kpisAsync = ref.watch(dashboardKpisProvider);
-    final monthFormat = DateFormat('MMMM yyyy');
-
     monthlyTotalsAsync.whenData(_ensureSelectedMonthIsAvailable);
 
     return Scaffold(
@@ -101,7 +100,7 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
                 const SizedBox(height: AppSpacing.lg),
                 Text(
                   t.spendingByCategoryForMonth(
-                    monthFormat.format(selectedMonth),
+                    t.formatMonthYear(selectedMonth),
                   ),
                   style: AppTextStyles.titleMedium.copyWith(
                     color: AppColors.textPrimary,
@@ -112,7 +111,6 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
                 const SizedBox(height: AppSpacing.lg),
                 _QuickInsights(
                   overview: monthOverviewAsync,
-                  monthFormat: monthFormat,
                 ),
               ],
             ),
@@ -317,8 +315,9 @@ class _MonthlyChart extends StatelessWidget {
                     touchTooltipData: BarTouchTooltipData(
                       getTooltipItem: (group, groupIndex, rod, rodIndex) {
                         final month = totals[groupIndex];
-                        final monthName = DateFormat('MMM yyyy')
-                            .format(DateTime(month.year, month.month));
+                        final monthName = t.formatMonthYearShort(
+                          DateTime(month.year, month.month),
+                        );
                         return BarTooltipItem(
                           '$monthName\n${currencyFormat.format(month.total)}',
                           const TextStyle(color: Colors.white),
@@ -336,8 +335,9 @@ class _MonthlyChart extends StatelessWidget {
                           if (index >= 0 && index < totals.length) {
                             final month = totals[index];
                             return Text(
-                              DateFormat('MMM')
-                                  .format(DateTime(month.year, month.month)),
+                              t.formatMonthAbbreviated(
+                                DateTime(month.year, month.month),
+                              ),
                               style: const TextStyle(fontSize: 10),
                             );
                           }
@@ -413,7 +413,7 @@ class _MonthDropdown extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final monthFormat = DateFormat('MMMM yyyy');
+    final t = AppLocalizations.of(context)!;
     final normalizedSelected =
         DateTime(selectedMonth.year, selectedMonth.month);
 
@@ -430,7 +430,7 @@ class _MonthDropdown extends ConsumerWidget {
           .map(
             (month) => DropdownMenuItem(
               value: month,
-              child: Text(monthFormat.format(month)),
+              child: Text(t.formatMonthYear(month)),
             ),
           )
           .toList(),
@@ -486,7 +486,7 @@ class _TopCategoriesSection extends StatelessWidget {
                   (category) => Padding(
                     padding: const EdgeInsets.only(bottom: AppSpacing.sm),
                     child: _CategoryBar(
-                      name: category.categoryName,
+                      name: t.categoryLabel(category.categoryId),
                       amount: category.amount,
                       maxAmount: maxAmount,
                       formattedAmount: currencyFormat.format(category.amount),
@@ -577,11 +577,9 @@ class _CategoryBar extends StatelessWidget {
 class _QuickInsights extends StatelessWidget {
   const _QuickInsights({
     required this.overview,
-    required this.monthFormat,
   });
 
   final AsyncValue<MonthOverview> overview;
-  final DateFormat monthFormat;
 
   @override
   Widget build(BuildContext context) {
@@ -610,7 +608,7 @@ class _QuickInsights extends StatelessWidget {
             Expanded(
               child: _InsightCard(
                 title: t.maxReceiptForMonth(
-                  monthFormat.format(data.month),
+                  t.formatMonthYear(data.month),
                 ),
                 value: maxReceipt == null
                     ? '—'
@@ -622,7 +620,7 @@ class _QuickInsights extends StatelessWidget {
             Expanded(
               child: _InsightCard(
                 title: t.totalForMonth(
-                  monthFormat.format(data.month),
+                  t.formatMonthYear(data.month),
                 ),
                 value: currencyFormat.format(data.total),
                 subtitle: receiptsLabel,

--- a/lib/features/month/month_view.dart
+++ b/lib/features/month/month_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:receipts/l10n/app_localizations.dart';
+import 'package:receipts/l10n/app_localizations_extensions.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/domain/models/month_overview.dart';
@@ -20,7 +21,6 @@ class MonthView extends ConsumerWidget {
     final monthlyTotalsAsync = ref.watch(monthlyTotalsProvider);
     final monthOverviewAsync = ref.watch(monthOverviewProvider(selectedMonth));
     final receiptsAsync = ref.watch(receiptsByMonthProvider(selectedMonth));
-    final monthFormat = DateFormat('MMMM yyyy');
     final currencyFormat = NumberFormat.currency(
       locale: 'en_US',
       symbol: 'PLN ',
@@ -57,7 +57,7 @@ class MonthView extends ConsumerWidget {
             const SizedBox(height: AppSpacing.lg),
             Text(
               t.spendingByCategoryForMonth(
-                monthFormat.format(selectedMonth),
+                t.formatMonthYear(selectedMonth),
               ),
               style: AppTextStyles.titleMedium.copyWith(
                 color: AppColors.textPrimary,
@@ -71,7 +71,7 @@ class MonthView extends ConsumerWidget {
                 Expanded(
                   child: _MetricCard(
                     title: t.totalForMonth(
-                      monthFormat.format(selectedMonth),
+                      t.formatMonthYear(selectedMonth),
                     ),
                     value: totalValue,
                   ),
@@ -211,7 +211,7 @@ class _MonthPicker extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final monthFormat = DateFormat('MMMM yyyy');
+    final t = AppLocalizations.of(context)!;
     final value = months.firstWhere(
       (month) =>
           month.year == selectedMonth.year &&
@@ -234,7 +234,7 @@ class _MonthPicker extends ConsumerWidget {
             .map(
               (month) => DropdownMenuItem(
                 value: month,
-                child: Text(monthFormat.format(month)),
+                child: Text(t.formatMonthYear(month)),
               ),
             )
             .toList(),
@@ -291,7 +291,7 @@ class _CategoryBreakdown extends StatelessWidget {
                   (category) => Padding(
                     padding: const EdgeInsets.only(bottom: AppSpacing.sm),
                     child: _CategoryBar(
-                      name: category.categoryName,
+                      name: t.categoryLabel(category.categoryId),
                       amount: category.amount,
                       maxAmount: maxAmount,
                       formattedAmount: currencyFormat.format(category.amount),

--- a/lib/features/receipts/receipts_view.dart
+++ b/lib/features/receipts/receipts_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:receipts/l10n/app_localizations.dart';
+import 'package:receipts/l10n/app_localizations_extensions.dart';
 
 import 'package:receipts/app/providers.dart';
 import 'package:receipts/domain/models/monthly_total.dart';
@@ -165,7 +166,7 @@ class _SearchAndFiltersState extends ConsumerState<_SearchAndFilters> {
                     ...widget.monthOptions.map(
                       (month) => DropdownMenuItem(
                         value: month,
-                        child: Text(DateFormat('MMMM yyyy').format(month)),
+                        child: Text(t.formatMonthYear(month)),
                       ),
                     ),
                   ],

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -76,6 +76,12 @@
     }
   },
   "noCategorizedSpending": "No categorized spending for this month yet",
+  "categoryFreshProduce": "Fresh Produce & Vegetables",
+  "categoryDairyEggsBakery": "Dairy, Eggs & Bakery",
+  "categoryPackagedPantry": "Packaged & Pantry Foods",
+  "categoryDrinksSnacks": "Drinks & Snacks",
+  "categoryHouseholdGoods": "Household Goods",
+  "categoryMisc": "Miscellaneous / Other",
   "totalWithAmount": "Total — {amount}",
   "@totalWithAmount": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -419,6 +419,42 @@ abstract class AppLocalizations {
   /// **'No categorized spending for this month yet'**
   String get noCategorizedSpending;
 
+  /// No description provided for @categoryFreshProduce.
+  ///
+  /// In en, this message translates to:
+  /// **'Fresh Produce & Vegetables'**
+  String get categoryFreshProduce;
+
+  /// No description provided for @categoryDairyEggsBakery.
+  ///
+  /// In en, this message translates to:
+  /// **'Dairy, Eggs & Bakery'**
+  String get categoryDairyEggsBakery;
+
+  /// No description provided for @categoryPackagedPantry.
+  ///
+  /// In en, this message translates to:
+  /// **'Packaged & Pantry Foods'**
+  String get categoryPackagedPantry;
+
+  /// No description provided for @categoryDrinksSnacks.
+  ///
+  /// In en, this message translates to:
+  /// **'Drinks & Snacks'**
+  String get categoryDrinksSnacks;
+
+  /// No description provided for @categoryHouseholdGoods.
+  ///
+  /// In en, this message translates to:
+  /// **'Household Goods'**
+  String get categoryHouseholdGoods;
+
+  /// No description provided for @categoryMisc.
+  ///
+  /// In en, this message translates to:
+  /// **'Miscellaneous / Other'**
+  String get categoryMisc;
+
   /// No description provided for @totalWithAmount.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -179,6 +179,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noCategorizedSpending => 'No categorized spending for this month yet';
 
   @override
+  String get categoryFreshProduce => 'Fresh Produce & Vegetables';
+
+  @override
+  String get categoryDairyEggsBakery => 'Dairy, Eggs & Bakery';
+
+  @override
+  String get categoryPackagedPantry => 'Packaged & Pantry Foods';
+
+  @override
+  String get categoryDrinksSnacks => 'Drinks & Snacks';
+
+  @override
+  String get categoryHouseholdGoods => 'Household Goods';
+
+  @override
+  String get categoryMisc => 'Miscellaneous / Other';
+
+  @override
   String totalWithAmount(Object amount) {
     return 'Total — $amount';
   }

--- a/lib/l10n/app_localizations_extensions.dart
+++ b/lib/l10n/app_localizations_extensions.dart
@@ -1,0 +1,26 @@
+import 'package:intl/intl.dart';
+import 'package:receipts/domain/category_definitions.dart';
+import 'package:receipts/l10n/app_localizations.dart';
+
+extension AppLocalizationsX on AppLocalizations {
+  String formatMonthYear(DateTime date) =>
+      DateFormat('MMMM yyyy', localeName).format(date);
+
+  String formatMonthYearShort(DateTime date) =>
+      DateFormat('MMM yyyy', localeName).format(date);
+
+  String formatMonthAbbreviated(DateTime date) =>
+      DateFormat('MMM', localeName).format(date);
+
+  Map<String, String> get _categoryLabels => {
+        CategoryIds.freshProduce: categoryFreshProduce,
+        CategoryIds.dairyEggsBakery: categoryDairyEggsBakery,
+        CategoryIds.packagedPantry: categoryPackagedPantry,
+        CategoryIds.drinksSnacks: categoryDrinksSnacks,
+        CategoryIds.householdGoods: categoryHouseholdGoods,
+        CategoryIds.misc: categoryMisc,
+      };
+
+  String categoryLabel(String categoryId) =>
+      _categoryLabels[categoryId] ?? _categoryLabels[CategoryIds.misc]!;
+}

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -179,6 +179,24 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noCategorizedSpending => 'За этот месяц ещё нет расходов по категориям';
 
   @override
+  String get categoryFreshProduce => 'Свежие продукты и овощи';
+
+  @override
+  String get categoryDairyEggsBakery => 'Молочные продукты, яйца и выпечка';
+
+  @override
+  String get categoryPackagedPantry => 'Упакованные продукты и бакалея';
+
+  @override
+  String get categoryDrinksSnacks => 'Напитки и снеки';
+
+  @override
+  String get categoryHouseholdGoods => 'Товары для дома';
+
+  @override
+  String get categoryMisc => 'Разное / Другое';
+
+  @override
   String totalWithAmount(Object amount) {
     return 'Итого — $amount';
   }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -76,6 +76,12 @@
     }
   },
   "noCategorizedSpending": "За этот месяц ещё нет расходов по категориям",
+  "categoryFreshProduce": "Свежие продукты и овощи",
+  "categoryDairyEggsBakery": "Молочные продукты, яйца и выпечка",
+  "categoryPackagedPantry": "Упакованные продукты и бакалея",
+  "categoryDrinksSnacks": "Напитки и снеки",
+  "categoryHouseholdGoods": "Товары для дома",
+  "categoryMisc": "Разное / Другое",
   "totalWithAmount": "Итого — {amount}",
   "@totalWithAmount": {
     "placeholders": {

--- a/test/l10n/category_localizations_test.dart
+++ b/test/l10n/category_localizations_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:receipts/domain/category_definitions.dart';
+import 'package:receipts/l10n/app_localizations_en.dart';
+import 'package:receipts/l10n/app_localizations_extensions.dart';
+
+void main() {
+  test('every category has a localized label', () {
+    final t = AppLocalizationsEn();
+
+    for (final definition in categoryDefinitions) {
+      final label = t.categoryLabel(definition.id);
+      expect(label, isNotEmpty,
+          reason: 'Missing localization for ${definition.id}');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add localization helpers for month formatting and category labels
- update dashboard, month, and receipts screens to use the localized labels
- add a test to ensure every category has a translation key

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68fe437fed40832f84b7032327e47dfe