### PR TITLE
Run SonarQube scan from Android debug workflow

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -1,6 +1,8 @@
 name: Android Debug APK
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -19,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -41,9 +45,22 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         run: flutter pub get
 
+      - name: Flutter analyze
+        working-directory: ${{ env.PROJECT_DIR }}
+        run: flutter analyze
+
+      - name: Flutter test
+        working-directory: ${{ env.PROJECT_DIR }}
+        run: flutter test
+
       - name: Build debug APK
         working-directory: ${{ env.PROJECT_DIR }}
         run: flutter build apk --debug
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Upload artifact (app-debug.apk)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -61,6 +61,7 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: Upload artifact (app-debug.apk)
         uses: actions/upload-artifact@v4

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=shatokh_Receipts
+sonar.organization=shatokh
+sonar.projectName=Receipts
+sonar.projectVersion=1.0
+sonar.sourceEncoding=UTF-8
+sonar.sources=lib
+sonar.tests=test
+sonar.exclusions=**/build/**,**/*.g.dart


### PR DESCRIPTION
## Summary
- extend the Android debug workflow to cover push builds, analysis, tests, and SonarQube scanning
- reuse the existing job for SonarQube instead of maintaining a separate workflow file

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_690612a15f50832f85cfb5714aa260e0