### PR TITLE
Fix analyzer warnings for Android workflow

### DIFF
--- a/integration_test/app_flow_test.dart
+++ b/integration_test/app_flow_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -37,7 +36,7 @@ Future<void> pumpAndSettleSafe(
       );
       return;
     } on FlutterError catch (error) {
-      final message = error.message ?? error.toString();
+      final message = error.message;
       if (!message.contains('pumpAndSettle timed out')) {
         rethrow;
       }

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -13,7 +13,7 @@ class DatabaseHelper {
 
   static void configureForTesting({String? databaseName}) {
     _databaseNameOverride = databaseName;
-    if (!kIsWeb && databaseFactoryOrNull == null) {
+    if (!kIsWeb) {
       sqfliteFfiInit();
       databaseFactory = databaseFactoryFfi;
     }
@@ -40,15 +40,13 @@ class DatabaseHelper {
     var path = join(dbPath, name);
 
     if (!kIsWeb && _databaseNameOverride == null) {
-      final factory = databaseFactoryOrNull;
-      if (factory != null) {
-        final legacyPath = join(dbPath, legacyDbName);
-        final hasLegacy = await factory.databaseExists(legacyPath);
-        final hasNew = await factory.databaseExists(path);
+      final factory = databaseFactory;
+      final legacyPath = join(dbPath, legacyDbName);
+      final hasLegacy = await factory.databaseExists(legacyPath);
+      final hasNew = await factory.databaseExists(path);
 
-        if (hasLegacy && !hasNew) {
-          path = legacyPath;
-        }
+      if (hasLegacy && !hasNew) {
+        path = legacyPath;
       }
     }
 

--- a/lib/domain/category_definitions.dart
+++ b/lib/domain/category_definitions.dart
@@ -25,7 +25,7 @@ const List<CategoryDefinition> categoryDefinitions = [
   CategoryDefinition(
     id: CategoryIds.freshProduce,
     fallbackLabel: 'Fresh Produce & Vegetables',
-    keywords: const [
+    keywords: [
       'jabł',
       'jabl',
       'banan',
@@ -56,12 +56,12 @@ const List<CategoryDefinition> categoryDefinitions = [
       'berry',
       'herb',
     ],
-    legacyIds: const ['produce'],
+    legacyIds: ['produce'],
   ),
   CategoryDefinition(
     id: CategoryIds.dairyEggsBakery,
     fallbackLabel: 'Dairy, Eggs & Bakery',
-    keywords: const [
+    keywords: [
       'mleko',
       'milk',
       'ser',
@@ -95,12 +95,12 @@ const List<CategoryDefinition> categoryDefinitions = [
       'bake',
       'bakery',
     ],
-    legacyIds: const ['dairy', 'bakery'],
+    legacyIds: ['dairy', 'bakery'],
   ),
   CategoryDefinition(
     id: CategoryIds.packagedPantry,
     fallbackLabel: 'Packaged & Pantry Foods',
-    keywords: const [
+    keywords: [
       'makaron',
       'pasta',
       'ryż',
@@ -152,12 +152,12 @@ const List<CategoryDefinition> categoryDefinitions = [
       'broth',
       'bouillon',
     ],
-    legacyIds: const ['meat'],
+    legacyIds: ['meat'],
   ),
   CategoryDefinition(
     id: CategoryIds.drinksSnacks,
     fallbackLabel: 'Drinks & Snacks',
-    keywords: const [
+    keywords: [
       'napój',
       'napoj',
       'sok',
@@ -195,7 +195,7 @@ const List<CategoryDefinition> categoryDefinitions = [
   CategoryDefinition(
     id: CategoryIds.householdGoods,
     fallbackLabel: 'Household Goods',
-    keywords: const [
+    keywords: [
       'papier',
       'deterg',
       'mydł',
@@ -227,12 +227,12 @@ const List<CategoryDefinition> categoryDefinitions = [
       'toalet',
       'toilet',
     ],
-    legacyIds: const ['household'],
+    legacyIds: ['household'],
   ),
   CategoryDefinition(
     id: CategoryIds.misc,
     fallbackLabel: 'Miscellaneous / Other',
-    legacyIds: const ['other'],
+    legacyIds: ['other'],
   ),
 ];
 

--- a/lib/features/import/import_service.dart
+++ b/lib/features/import/import_service.dart
@@ -117,8 +117,11 @@ class ImportService {
 
   String _mapImportError(Object error) {
     if (error is FormatException) {
-      return error.message ??
-          'The receipt file could not be parsed because its structure is invalid.';
+      final message = error.message;
+      if (message.isEmpty) {
+        return 'The receipt file could not be parsed because its structure is invalid.';
+      }
+      return message;
     }
     if (error is PdfTextExtractionException) {
       return 'The receipt file could not be read. ${error.message}';


### PR DESCRIPTION
## Summary
- remove analyzer warnings in integration test and import service
- avoid using visible-for-testing database API in production code
- clean up redundant const literals in category definitions

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_6906211022d0832f81d3c7063aeec4ff