### PR TITLE
Fix deprecated Flutter inputs in receipts filters and language selection

### DIFF
--- a/lib/features/receipts/receipts_view.dart
+++ b/lib/features/receipts/receipts_view.dart
@@ -106,11 +106,13 @@ class _SearchAndFilters extends ConsumerStatefulWidget {
 
 class _SearchAndFiltersState extends ConsumerState<_SearchAndFilters> {
   late final TextEditingController _controller;
+  late final FormFieldController<DateTime?> _monthController;
 
   @override
   void initState() {
     super.initState();
     _controller = TextEditingController(text: widget.searchQuery);
+    _monthController = FormFieldController<DateTime?>(widget.selectedMonth);
   }
 
   @override
@@ -121,6 +123,11 @@ class _SearchAndFiltersState extends ConsumerState<_SearchAndFilters> {
         text: widget.searchQuery,
         selection: TextSelection.collapsed(offset: widget.searchQuery.length),
       );
+    }
+
+    if (widget.selectedMonth != oldWidget.selectedMonth &&
+        widget.selectedMonth != _monthController.value) {
+      _monthController.value = widget.selectedMonth;
     }
   }
 
@@ -153,7 +160,8 @@ class _SearchAndFiltersState extends ConsumerState<_SearchAndFilters> {
 
               Widget buildMonthDropdown({bool expandWidth = false}) {
                 final dropdown = DropdownButtonFormField<DateTime?>(
-                  value: widget.selectedMonth,
+                  controller: _monthController,
+                  initialValue: widget.selectedMonth,
                   decoration: InputDecoration(
                     labelText: t.monthFilterLabel,
                     border: const OutlineInputBorder(),

--- a/lib/features/settings/language_page.dart
+++ b/lib/features/settings/language_page.dart
@@ -19,17 +19,26 @@ class LanguagePage extends ConsumerWidget {
         children: [
           ListTile(title: Text(t.chooseLanguage)),
           const Divider(),
-          RadioListTile<Locale>(
-            value: const Locale('en'),
-            groupValue: current,
-            onChanged: (_) => controller.setLocale(const Locale('en')),
-            title: Text(t.english),
-          ),
-          RadioListTile<Locale>(
-            value: const Locale('ru'),
-            groupValue: current,
-            onChanged: (_) => controller.setLocale(const Locale('ru')),
-            title: Text(t.russian),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: SegmentedButton<Locale>(
+              segments: [
+                ButtonSegment(
+                  value: const Locale('en'),
+                  label: Text(t.english),
+                ),
+                ButtonSegment(
+                  value: const Locale('ru'),
+                  label: Text(t.russian),
+                ),
+              ],
+              selected: {current},
+              onSelectionChanged: (selection) {
+                if (selection.isNotEmpty) {
+                  controller.setLocale(selection.first);
+                }
+              },
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- replace the deprecated DropdownButtonFormField value parameter with a form field controller that tracks the selected month
- update the language settings page to use a segmented button instead of deprecated radio list tiles

## Testing
- flutter analyze *(fails: command hung in this environment after downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_69065e1493a0832fae36fc9bffb923d3