### PR TITLE
Fix receipts month dropdown to use initialValue

### DIFF
--- a/lib/features/receipts/receipts_view.dart
+++ b/lib/features/receipts/receipts_view.dart
@@ -154,7 +154,7 @@ class _SearchAndFiltersState extends ConsumerState<_SearchAndFilters> {
 
               Widget buildMonthDropdown({bool expandWidth = false}) {
                 final dropdown = DropdownButtonFormField<DateTime?>(
-                  value: widget.selectedMonth,
+                  initialValue: widget.selectedMonth,
                   decoration: InputDecoration(
                     labelText: t.monthFilterLabel,
                     border: const OutlineInputBorder(),


### PR DESCRIPTION
## Summary
- replace the deprecated `value` usage on the receipts month dropdown with `initialValue`

## Testing
- flutter analyze *(fails: local Flutter SDK version 0.0.0-unknown, required >=3.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_6907944deb38832fbc73f9ceb0ac4edf