### PR TITLE
Ensure SonarQube scan uses valid host URL

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -61,7 +61,7 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL != '' && secrets.SONAR_HOST_URL || 'https://sonarcloud.io' }}
 
       - name: Upload artifact (app-debug.apk)
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- provide a default SonarQube host URL when the secret is empty so the scan uses a valid scheme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907b44d48b8832f9103aeea5e3f35af