### PR TITLE
Improve PDF import extraction diagnostics

### DIFF
--- a/android/app/src/main/kotlin/app/receipts/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/receipts/MainActivity.kt
@@ -7,6 +7,7 @@ import android.graphics.Matrix
 import android.graphics.pdf.PdfRenderer
 import android.os.Handler
 import android.os.Looper
+import android.util.Base64
 import android.util.Log
 import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterActivity
@@ -27,12 +28,16 @@ import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
 import java.io.InputStream
-import java.lang.Integer.max
 import java.security.MessageDigest
 import java.text.Normalizer
+import java.util.Locale
 import java.util.zip.GZIPInputStream
 import java.util.zip.ZipInputStream
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.text.Charsets.UTF_8
 import org.json.JSONArray
 import org.json.JSONException
@@ -61,7 +66,15 @@ class MainActivity : FlutterActivity() {
                         } catch (e: Exception) {
                             Log.e(TAG, "extractTextPages failed for $safUri", e)
                             mainHandler.post {
-                                result.error("EXTRACTION_ERROR", e.message, e.toString())
+                                if (e is EmptyPdfTextException) {
+                                    result.error(
+                                        "EMPTY_PDF_TEXT",
+                                        e.message,
+                                        e.stages,
+                                    )
+                                } else {
+                                    result.error("EXTRACTION_ERROR", e.message, e.toString())
+                                }
                             }
                         }
                     }
@@ -117,10 +130,12 @@ class MainActivity : FlutterActivity() {
         val uri = Uri.parse(safUri)
         val inputStream: InputStream = contentResolver.openInputStream(uri)
             ?: throw Exception("Cannot open file")
-        
+
         return inputStream.use { stream ->
             PDDocument.load(stream).use { document ->
-                extractEmbeddedReceipt(document)?.let { payload ->
+                val embeddedResult = extractEmbeddedReceipt(document)
+                logExtractionStage(safUri, "embedded", embeddedResult.status)
+                embeddedResult.value?.let { payload ->
                     return payload
                 }
 
@@ -139,17 +154,32 @@ class MainActivity : FlutterActivity() {
 
                     pages.add(text)
                 }
-                if (hasMeaningfulText(pages)) {
+
+                val stripperStatus = if (hasMeaningfulText(pages)) {
+                    StageStatus.SUCCESS
+                } else {
+                    StageStatus.EMPTY
+                }
+                logExtractionStage(safUri, "stripper", stripperStatus)
+
+                if (stripperStatus == StageStatus.SUCCESS) {
                     return pages
                 }
 
-                val ocrPages = extractTextWithOcr(uri)
-                if (hasMeaningfulText(ocrPages)) {
+                val ocrResult = extractTextWithOcr(uri)
+                logExtractionStage(safUri, "ocr", ocrResult.status)
+                if (hasMeaningfulText(ocrResult.value ?: emptyList())) {
                     Log.i(TAG, "Falling back to OCR text extraction for $safUri")
-                    return ocrPages
+                    return ocrResult.value ?: pages
                 }
 
-                pages
+                val stages = mapOf(
+                    "embedded" to embeddedResult.status.value,
+                    "stripper" to stripperStatus.value,
+                    "ocr" to ocrResult.status.value,
+                )
+
+                throw EmptyPdfTextException(stages)
             }
         }
     }
@@ -192,64 +222,127 @@ class MainActivity : FlutterActivity() {
         return inputStream.bufferedReader(UTF_8).use { it.readText() }
     }
 
-    private fun extractEmbeddedReceipt(document: PDDocument): List<String>? {
+    private fun extractEmbeddedReceipt(document: PDDocument): StageResult<List<String>> {
         val nameDictionary: PDDocumentNameDictionary? = document.documentCatalog.names
         val embeddedTree = nameDictionary?.embeddedFiles
-        extractFromEmbeddedTree(embeddedTree)?.let { return listOf(it) }
+        val treeResult = extractFromEmbeddedTree(embeddedTree)
+        treeResult.value?.let { payload ->
+            return StageResult(listOf(payload), StageStatus.SUCCESS)
+        }
+
+        var status = treeResult.status
 
         // Some PDFs store attachments directly on pages as annotations.
         for (page in document.pages) {
             for (annotation in page.annotations) {
                 if (annotation is PDAnnotationFileAttachment) {
-                    decodeEmbeddedFile(annotation.file)?.let { return listOf(it) }
+                    val attachmentResult = decodeEmbeddedFile(annotation.file)
+                    status = dominantStatus(status, attachmentResult.status)
+                    attachmentResult.value?.let { payload ->
+                        return StageResult(listOf(payload), StageStatus.SUCCESS)
+                    }
                 }
             }
         }
 
-        return null
+        return StageResult(null, status)
     }
 
-    private fun extractTextWithOcr(uri: Uri): List<String> {
+    private fun extractTextWithOcr(uri: Uri): StageResult<List<String>> {
         return try {
             contentResolver.openFileDescriptor(uri, "r")?.use { descriptor ->
                 PdfRenderer(descriptor).use { renderer ->
                     if (renderer.pageCount == 0) {
-                        return emptyList()
+                        return StageResult(emptyList(), StageStatus.EMPTY)
                     }
 
                     val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
                     try {
                         val pages = mutableListOf<String>()
+                        var status = StageStatus.EMPTY
+
                         for (i in 0 until renderer.pageCount) {
                             renderer.openPage(i).use { page ->
-                                val scale = computeOcrScale(page.width, page.height)
-                                val width = (page.width * scale).toInt()
-                                val height = (page.height * scale).toInt()
-                                val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-                                try {
-                                    bitmap.eraseColor(Color.WHITE)
-                                    val matrix = Matrix().apply { postScale(scale, scale) }
-                                    page.render(bitmap, null, matrix, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                                val primaryScale = computeOcrScale(page.width, page.height)
+                                val primaryText = runOcrPass(page, recognizer, primaryScale, applyBinarization = false)
 
-                                    val image = InputImage.fromBitmap(bitmap, 0)
-                                    val result = Tasks.await(recognizer.process(image))
-                                    val normalized = Normalizer.normalize(result.text, Normalizer.Form.NFC)
-                                    pages.add(normalized)
-                                } finally {
-                                    bitmap.recycle()
+                                val normalizedPrimary = Normalizer.normalize(primaryText, Normalizer.Form.NFC)
+
+                                val finalText = if (normalizedPrimary.isNotBlank()) {
+                                    normalizedPrimary
+                                } else {
+                                    val enhancedScale = (primaryScale * 1.35f).coerceAtMost(3.5f)
+                                    val secondaryText = runOcrPass(
+                                        page,
+                                        recognizer,
+                                        enhancedScale,
+                                        applyBinarization = true,
+                                    )
+                                    Normalizer.normalize(secondaryText, Normalizer.Form.NFC)
                                 }
+
+                                if (finalText.any { !it.isWhitespace() }) {
+                                    status = StageStatus.SUCCESS
+                                }
+
+                                pages.add(finalText)
                             }
                         }
-                        pages
+
+                        StageResult(pages, status)
                     } finally {
                         recognizer.close()
                     }
                 }
-            } ?: emptyList()
+            } ?: StageResult(emptyList(), StageStatus.EMPTY)
         } catch (e: Exception) {
             Log.e(TAG, "OCR fallback failed for $uri", e)
-            emptyList()
+            StageResult(emptyList(), StageStatus.ERROR)
         }
+    }
+
+    private fun runOcrPass(
+        page: PdfRenderer.Page,
+        recognizer: com.google.mlkit.vision.text.TextRecognizer,
+        scale: Float,
+        applyBinarization: Boolean,
+    ): String {
+        val width = (page.width * scale).toInt().coerceAtLeast(1)
+        val height = (page.height * scale).toInt().coerceAtLeast(1)
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        return try {
+            bitmap.eraseColor(Color.WHITE)
+            val matrix = Matrix().apply { postScale(scale, scale) }
+            page.render(bitmap, null, matrix, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+
+            if (applyBinarization) {
+                binarizeBitmap(bitmap)
+            }
+
+            val image = InputImage.fromBitmap(bitmap, 0)
+            val result = Tasks.await(recognizer.process(image))
+            result.text
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    private fun binarizeBitmap(bitmap: Bitmap) {
+        val width = bitmap.width
+        val height = bitmap.height
+        val pixels = IntArray(width * height)
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+
+        for (index in pixels.indices) {
+            val color = pixels[index]
+            val red = Color.red(color)
+            val green = Color.green(color)
+            val blue = Color.blue(color)
+            val luminance = (0.299 * red + 0.587 * green + 0.114 * blue).toInt()
+            pixels[index] = if (luminance > 180) Color.WHITE else Color.BLACK
+        }
+
+        bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
     }
 
     private fun computeOcrScale(width: Int, height: Int): Float {
@@ -273,72 +366,108 @@ class MainActivity : FlutterActivity() {
         return false
     }
 
+    private fun logExtractionStage(safUri: String, stage: String, status: StageStatus) {
+        Log.d(TAG, "Extraction stage $stage=${status.value} for $safUri")
+    }
+
     private fun extractFromEmbeddedTree(
         node: PDNameTreeNode<PDComplexFileSpecification>?,
-    ): String? {
+    ): StageResult<String> {
         if (node == null) {
-            return null
+            return StageResult(null, StageStatus.ABSENT)
         }
+
+        var status = StageStatus.ABSENT
 
         val names = node.names
         if (names != null) {
             for ((_, spec) in names) {
-                decodeEmbeddedFile(spec)?.let { return it }
+                val result = decodeEmbeddedFile(spec)
+                status = dominantStatus(status, result.status)
+                result.value?.let { return StageResult(it, StageStatus.SUCCESS) }
             }
         }
 
         val kids = node.kids
         if (kids != null) {
             for (child in kids) {
-                extractFromEmbeddedTree(child)?.let { return it }
+                val result = extractFromEmbeddedTree(child)
+                status = dominantStatus(status, result.status)
+                result.value?.let { return result }
             }
         }
 
-        return null
+        return StageResult(null, status)
     }
 
-    private fun decodeEmbeddedFile(spec: PDFileSpecification?): String? {
+    private fun decodeEmbeddedFile(spec: PDFileSpecification?): StageResult<String> {
         val complexSpec = when (spec) {
-            null -> return null
+            null -> return StageResult(null, StageStatus.ABSENT)
             is PDComplexFileSpecification -> spec
             else -> {
                 Log.w(TAG, "Unsupported embedded file specification type: ${spec.javaClass.simpleName}")
-                return null
+                return StageResult(null, StageStatus.INVALID)
             }
         }
 
-        val embeddedFile: PDEmbeddedFile =
-            complexSpec.embeddedFile ?: complexSpec.embeddedFileUnicode ?: return null
+        val embeddedFile: PDEmbeddedFile = complexSpec.embeddedFile
+            ?: complexSpec.embeddedFileUnicode
+            ?: return StageResult(null, StageStatus.EMPTY)
+
+        val attachmentName = listOfNotNull(
+            complexSpec.file,
+            complexSpec.fileUnicode,
+            embeddedFile.subtype,
+        ).firstOrNull().orEmpty()
 
         return embeddedFile.createInputStream().use { stream ->
             val rawBytes = stream.readAllBytes()
-            val decoded = decodeEmbeddedBytes(rawBytes, embeddedFile.subtype)
+            if (rawBytes.isNotEmpty()) {
+                dumpAttachment("${attachmentName}_raw", rawBytes)
+            }
+
+            val decoded = decodeEmbeddedBytes(rawBytes, embeddedFile.subtype, attachmentName)
+            if (decoded.isNotEmpty()) {
+                dumpAttachment("${attachmentName}_decoded", decoded)
+            }
+
             val text = decoded.toString(UTF_8)
             val cleanedText = sanitizeEmbeddedText(text)
 
             if (cleanedText.isEmpty()) {
-                Log.w(TAG, "Embedded receipt payload was empty")
-                return@use null
+                Log.w(TAG, "Embedded receipt payload was empty (${attachmentName.ifEmpty { "unnamed" }})")
+                return@use StageResult(null, StageStatus.EMPTY)
             }
 
             val mimeType = embeddedFile.subtype
             val isJsonPayload = isJsonMimeType(mimeType) || isValidJson(cleanedText)
 
-            if (isJsonPayload) cleanedText else null
+            if (isJsonPayload) {
+                Log.i(TAG, "Embedded receipt payload decoded from ${attachmentName.ifEmpty { "unnamed attachment" }}")
+                StageResult(cleanedText, StageStatus.SUCCESS)
+            } else {
+                Log.w(TAG, "Embedded receipt payload ${attachmentName.ifEmpty { "unnamed" }} was not JSON")
+                StageResult(null, StageStatus.INVALID)
+            }
         }
     }
 
     private fun decodeEmbeddedBytes(
         bytes: ByteArray,
-        mimeType: String?
+        mimeType: String?,
+        sourceName: String,
     ): ByteArray {
-        val lowerMime = mimeType?.lowercase() ?: ""
+        val lowerMime = mimeType?.lowercase(Locale.ROOT) ?: ""
 
-        return when {
-            isZipPayload(lowerMime, bytes) -> decodeZip(bytes)
+        var decoded = when {
+            isZipPayload(lowerMime, bytes) -> decodeZip(bytes, sourceName)
             isGzipPayload(lowerMime, bytes) -> decodeGzip(bytes)
             else -> bytes
         }
+
+        decoded = decodeNestedContainers(decoded, sourceName)
+
+        return decoded
     }
 
     private fun isZipPayload(mimeType: String, bytes: ByteArray): Boolean {
@@ -365,24 +494,99 @@ class MainActivity : FlutterActivity() {
             bytes[1] == 0x8b.toByte()
     }
 
-    private fun decodeZip(bytes: ByteArray): ByteArray {
+    private fun decodeZip(bytes: ByteArray, sourceName: String? = null): ByteArray {
         return try {
             ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
                 var entry = zip.nextEntry
                 while (entry != null) {
                     if (!entry.isDirectory) {
-                        val name = entry.name.lowercase()
-                        if (name.endsWith(".json") || name.endsWith(".txt")) {
-                            return zip.readAllBytes()
+                        val entryName = entry.name ?: "unnamed"
+                        val entryBytes = zip.readEntryBytes()
+                        val combinedName = listOfNotNull(sourceName, entryName).joinToString("_")
+                        if (entryBytes.isNotEmpty()) {
+                            dumpAttachment("${combinedName}_entry", entryBytes)
+                        }
+
+                        val candidate = decodeNestedContainers(entryBytes, entryName)
+                        val text = sanitizeEmbeddedText(candidate.toString(UTF_8))
+                        if (isValidJson(text)) {
+                            Log.i(TAG, "Decoded JSON from zip entry $entryName")
+                            return candidate
                         }
                     }
                     entry = zip.nextEntry
                 }
             }
             bytes
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to decode zip payload ${sourceName ?: ""}", e)
             bytes
         }
+    }
+
+    private fun decodeNestedContainers(bytes: ByteArray, sourceName: String): ByteArray {
+        var current = bytes
+        var iteration = 0
+
+        while (iteration < 3) {
+            iteration += 1
+            when {
+                isZipPayload("", current) -> {
+                    val decoded = decodeZip(current, sourceName)
+                    if (!decoded.contentEquals(current)) {
+                        current = decoded
+                        continue
+                    }
+                }
+                isGzipPayload("", current) -> {
+                    val decoded = decodeGzip(current)
+                    if (!decoded.contentEquals(current)) {
+                        current = decoded
+                        continue
+                    }
+                }
+                else -> {
+                    val decoded = tryDecodeBase64(current)
+                    if (decoded != null && !decoded.contentEquals(current)) {
+                        current = decoded
+                        continue
+                    }
+                }
+            }
+            break
+        }
+
+        return current
+    }
+
+    private fun tryDecodeBase64(bytes: ByteArray): ByteArray? {
+        val text = bytes.toString(UTF_8).trim()
+        if (text.length < 16) {
+            return null
+        }
+
+        val normalized = text
+            .replace("\n", "")
+            .replace("\r", "")
+            .trim()
+
+        if (normalized.length % 4 != 0) {
+            return null
+        }
+
+        if (normalized.any { !isBase64Character(it) }) {
+            return null
+        }
+
+        return try {
+            Base64.decode(normalized, Base64.DEFAULT)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+
+    private fun isBase64Character(char: Char): Boolean {
+        return char.isLetterOrDigit() || char == '+' || char == '/' || char == '='
     }
 
     private fun decodeGzip(bytes: ByteArray): ByteArray {
@@ -391,6 +595,50 @@ class MainActivity : FlutterActivity() {
         } catch (_: Exception) {
             bytes
         }
+    }
+
+    private fun dumpAttachment(rawName: String, bytes: ByteArray) {
+        if (bytes.isEmpty()) {
+            return
+        }
+
+        try {
+            val directory = File(cacheDir, "embedded-dumps")
+            if (!directory.exists()) {
+                directory.mkdirs()
+            }
+
+            val sanitized = rawName.ifEmpty { "payload" }
+                .lowercase(Locale.ROOT)
+                .replace(Regex("[^a-z0-9._-]"), "_")
+            val clipped = sanitized.take(40).ifEmpty { "payload" }
+            val fileName = "${System.currentTimeMillis()}_${clipped}.bin"
+            val target = File(directory, fileName)
+            val limit = min(bytes.size, 512 * 1024)
+
+            FileOutputStream(target).use { output ->
+                output.write(bytes, 0, limit)
+            }
+
+            Log.d(TAG, "Dumped embedded payload to ${target.absolutePath}")
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to dump embedded payload $rawName", e)
+        }
+    }
+
+    private fun ZipInputStream.readEntryBytes(): ByteArray {
+        val buffer = ByteArrayOutputStream()
+        val chunk = ByteArray(8192)
+
+        while (true) {
+            val read = read(chunk)
+            if (read <= 0) {
+                break
+            }
+            buffer.write(chunk, 0, read)
+        }
+
+        return buffer.toByteArray()
     }
 
     private fun sanitizeEmbeddedText(text: String): String {
@@ -423,6 +671,26 @@ class MainActivity : FlutterActivity() {
         } catch (_: JSONException) {
             false
         }
+    }
+
+    private enum class StageStatus(val value: String, val priority: Int) {
+        SUCCESS("success", 4),
+        ERROR("error", 3),
+        INVALID("invalid", 2),
+        EMPTY("empty", 1),
+        ABSENT("absent", 0);
+    }
+
+    private data class StageResult<T>(val value: T?, val status: StageStatus)
+
+    private class EmptyPdfTextException(
+        val stages: Map<String, String>,
+    ) : IllegalStateException(
+        "PDF does not contain any machine-readable text or embedded receipt data.",
+    )
+
+    private fun dominantStatus(first: StageStatus, second: StageStatus): StageStatus {
+        return if (first.priority >= second.priority) first else second
     }
 
     private fun InputStream.readAllBytes(): ByteArray {

--- a/lib/data/repositories/analytics_repository.dart
+++ b/lib/data/repositories/analytics_repository.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:developer' as developer;
 import 'dart:math';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -21,6 +23,24 @@ class AnalyticsRepository {
   final DatabaseUpdateBus _updateBus;
 
   Stream<void> get updates => _updateBus.stream;
+
+  void recordImportTelemetry({
+    required String sourceUri,
+    required String stage,
+    Map<String, dynamic> details = const {},
+  }) {
+    final payload = <String, dynamic>{
+      'source': sourceUri,
+      'stage': stage,
+      if (details.isNotEmpty) 'details': details,
+    };
+
+    developer.log(
+      'import_telemetry',
+      name: 'ImportTelemetry',
+      error: jsonEncode(payload),
+    );
+  }
 
   Stream<List<MonthlyTotal>> watchLast12MonthsTotals() {
     return Stream.multi((controller) async {

--- a/lib/features/import/import_service.dart
+++ b/lib/features/import/import_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:receipts/data/repositories/analytics_repository.dart';
@@ -96,7 +97,23 @@ class ImportService {
       }
 
       return parser.parse(text);
-    } on PdfTextExtractionException {
+    } on FormatException catch (error) {
+      if (_isEmptyPdfFormatError(error)) {
+        _recordExtractionTelemetry(
+          safUri: safUri,
+          outcome: 'normalized_text_empty',
+          details: {'message': error.message},
+        );
+        return _parseTextFile(safUri);
+      }
+      rethrow;
+    } on PdfTextExtractionException catch (error) {
+      final stageDetails = _decodeStageDetails(error.details);
+      _recordExtractionTelemetry(
+        safUri: safUri,
+        outcome: 'empty_pdf_text',
+        details: stageDetails ?? {'message': error.message},
+      );
       return _parseTextFile(safUri);
     }
   }
@@ -124,6 +141,11 @@ class ImportService {
       return message;
     }
     if (error is PdfTextExtractionException) {
+      final stageDetails = _decodeStageDetails(error.details);
+      final ocrStatus = stageDetails?['ocr']?.toString();
+      if (ocrStatus == 'empty' || ocrStatus == 'error') {
+        return 'Unable to extract text from the PDF. OCR models may still be downloading. Use Retry OCR after the download completes or import the JSON export from the Receipts app.';
+      }
       return 'The receipt file could not be read. ${error.message}';
     }
     return 'Unexpected error while importing the receipt: ${error.toString()}';
@@ -138,5 +160,40 @@ class ImportService {
         ..write('\n');
     }
     return buffer.toString().trimRight();
+  }
+
+  void _recordExtractionTelemetry({
+    required String safUri,
+    required String outcome,
+    Map<String, dynamic>? details,
+  }) {
+    analytics.recordImportTelemetry(
+      sourceUri: safUri,
+      stage: outcome,
+      details: details ?? const {},
+    );
+  }
+
+  Map<String, dynamic>? _decodeStageDetails(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+    } catch (_) {
+      // ignore malformed detail payloads
+    }
+
+    return null;
+  }
+
+  bool _isEmptyPdfFormatError(FormatException error) {
+    final normalized = error.message.toLowerCase();
+    return normalized.contains('machine-readable text') ||
+        normalized.contains('pdf does not contain');
   }
 }

--- a/lib/features/import/import_view.dart
+++ b/lib/features/import/import_view.dart
@@ -20,10 +20,16 @@ class ImportView extends ConsumerWidget {
     final historyContent = importState.maybeWhen(
       data: (results) => results.isEmpty
           ? const _EmptyState()
-          : _ImportHistoryList(entries: entries),
+          : _ImportHistoryList(
+              entries: entries,
+              onRetry: (uri) => controller.importUris([uri]),
+            ),
       orElse: () => entries.isEmpty
           ? const _EmptyState()
-          : _ImportHistoryList(entries: entries),
+          : _ImportHistoryList(
+              entries: entries,
+              onRetry: (uri) => controller.importUris([uri]),
+            ),
     );
 
     return Scaffold(
@@ -95,10 +101,27 @@ class _LoadingOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return ColoredBox(
       color: Colors.black.withValues(alpha: 0.05),
-      child: const Center(
-        child: CircularProgressIndicator(),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: AppSpacing.md),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xl),
+              child: Text(
+                t.ocrInProgressMessage,
+                style: AppTextStyles.bodyMedium.copyWith(
+                  color: AppColors.textPrimary,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -140,25 +163,36 @@ class _EmptyState extends StatelessWidget {
 }
 
 class _ImportHistoryList extends StatelessWidget {
-  const _ImportHistoryList({required this.entries});
+  const _ImportHistoryList({
+    required this.entries,
+    required this.onRetry,
+  });
 
   final List<ImportHistoryEntry> entries;
+  final void Function(String safUri) onRetry;
 
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
       itemCount: entries.length,
       itemBuilder: (context, index) {
-        return _ImportHistoryItem(entry: entries[index]);
+        return _ImportHistoryItem(
+          entry: entries[index],
+          onRetry: onRetry,
+        );
       },
     );
   }
 }
 
 class _ImportHistoryItem extends StatelessWidget {
-  const _ImportHistoryItem({required this.entry});
+  const _ImportHistoryItem({
+    required this.entry,
+    required this.onRetry,
+  });
 
   final ImportHistoryEntry entry;
+  final void Function(String safUri) onRetry;
 
   ImportResult get result => entry.result;
 
@@ -168,6 +202,12 @@ class _ImportHistoryItem extends StatelessWidget {
     final fileName = _resolveFileName(t, result.sourceUri);
     final subtitle = _buildSubtitle(t, entry.timestamp, result.message);
     final badgeStyle = _badgeStyle(result.status, t);
+    final retryButton = result.status == ImportStatus.error
+        ? TextButton(
+            onPressed: () => onRetry(result.sourceUri),
+            child: Text(t.retryOcrButtonLabel),
+          )
+        : null;
 
     return Card(
       child: ListTile(
@@ -177,11 +217,17 @@ class _ImportHistoryItem extends StatelessWidget {
             color: AppColors.textPrimary,
           ),
         ),
-        subtitle: Text(
-          subtitle,
-          style: AppTextStyles.bodyMedium.copyWith(
-            color: AppColors.textSecondary,
-          ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              subtitle,
+              style: AppTextStyles.bodyMedium.copyWith(
+                color: AppColors.textSecondary,
+              ),
+            ),
+            if (retryButton != null) retryButton,
+          ],
         ),
         trailing: _StatusBadge(
           label: badgeStyle.label,
@@ -207,7 +253,8 @@ class _ImportHistoryItem extends StatelessWidget {
   _BadgeStyle _badgeStyle(ImportStatus status, AppLocalizations t) {
     switch (status) {
       case ImportStatus.success:
-        return _BadgeStyle(label: t.importStatusSuccess, color: AppColors.success);
+        return _BadgeStyle(
+            label: t.importStatusSuccess, color: AppColors.success);
       case ImportStatus.duplicate:
         return _BadgeStyle(
           label: t.importStatusDuplicate,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -110,6 +110,8 @@
   "importStatusSuccess": "Success",
   "importStatusDuplicate": "Duplicate",
   "importStatusError": "Error",
+  "ocrInProgressMessage": "Performing OCR. The first run may take longer while text recognition models download.",
+  "retryOcrButtonLabel": "Retry OCR",
   "unknownFile": "Unknown file",
   "justNow": "Just now",
   "minutesAgo": "{count, plural, one {{count} min ago} other {{count} min ago}}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -538,6 +538,18 @@ abstract class AppLocalizations {
   /// **'Error'**
   String get importStatusError;
 
+  /// No description provided for @ocrInProgressMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Performing OCR. The first run may take longer while text recognition models download.'**
+  String get ocrInProgressMessage;
+
+  /// No description provided for @retryOcrButtonLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry OCR'**
+  String get retryOcrButtonLabel;
+
   /// No description provided for @unknownFile.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -251,6 +251,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importStatusError => 'Error';
 
   @override
+  String get ocrInProgressMessage =>
+      'Performing OCR. The first run may take longer while text recognition models download.';
+
+  @override
+  String get retryOcrButtonLabel => 'Retry OCR';
+
+  @override
   String get unknownFile => 'Unknown file';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -255,6 +255,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get importStatusError => 'Błąd';
 
   @override
+  String get ocrInProgressMessage =>
+      'Trwa rozpoznawanie tekstu (OCR). Pierwsze uruchomienie może potrwać dłużej podczas pobierania modeli.';
+
+  @override
+  String get retryOcrButtonLabel => 'Ponów OCR';
+
+  @override
   String get unknownFile => 'Nieznany plik';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -254,6 +254,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get importStatusError => 'Ошибка';
 
   @override
+  String get ocrInProgressMessage =>
+      'Выполняется распознавание текста (OCR). Первый запуск может занять больше времени из-за загрузки моделей.';
+
+  @override
+  String get retryOcrButtonLabel => 'Повторить OCR';
+
+  @override
   String get unknownFile => 'Неизвестный файл';
 
   @override

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -110,6 +110,8 @@
   "importStatusSuccess": "Sukces",
   "importStatusDuplicate": "Duplikat",
   "importStatusError": "Błąd",
+  "ocrInProgressMessage": "Trwa rozpoznawanie tekstu (OCR). Pierwsze uruchomienie może potrwać dłużej podczas pobierania modeli.",
+  "retryOcrButtonLabel": "Ponów OCR",
   "unknownFile": "Nieznany plik",
   "justNow": "Przed chwilą",
   "minutesAgo": "{count, plural, one {{count} min temu} few {{count} min temu} many {{count} min temu} other {{count} min temu}}",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -110,6 +110,8 @@
   "importStatusSuccess": "Успех",
   "importStatusDuplicate": "Дубликат",
   "importStatusError": "Ошибка",
+  "ocrInProgressMessage": "Выполняется распознавание текста (OCR). Первый запуск может занять больше времени из-за загрузки моделей.",
+  "retryOcrButtonLabel": "Повторить OCR",
   "unknownFile": "Неизвестный файл",
   "justNow": "Только что",
   "minutesAgo": "{count, plural, one {{count} мин назад} few {{count} мин назад} many {{count} мин назад} other {{count} мин назад}}",

--- a/lib/platform/pdf_text_extractor/android_pdf_text_extractor.dart
+++ b/lib/platform/pdf_text_extractor/android_pdf_text_extractor.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
 import 'pdf_text_extractor.dart';
@@ -16,9 +18,16 @@ class AndroidPdfTextExtractor implements PdfTextExtractor {
       final result = await _channel.invokeMethod('extractTextPages', safUri);
       return List<String>.from(result);
     } on PlatformException catch (e) {
+      if (e.code == 'EMPTY_PDF_TEXT') {
+        throw PdfTextExtractionException(
+          e.message ??
+              'PDF does not contain any machine-readable text or embedded receipt data.',
+          _encodeDetails(e.details),
+        );
+      }
       throw PdfTextExtractionException(
         'Failed to extract text: ${e.message}',
-        e.details?.toString(),
+        _encodeDetails(e.details),
       );
     }
   }
@@ -34,7 +43,7 @@ class AndroidPdfTextExtractor implements PdfTextExtractor {
     } on PlatformException catch (e) {
       throw PdfTextExtractionException(
         'Failed to get page count: ${e.message}',
-        e.details?.toString(),
+        _encodeDetails(e.details),
       );
     }
   }
@@ -50,7 +59,7 @@ class AndroidPdfTextExtractor implements PdfTextExtractor {
     } on PlatformException catch (e) {
       throw PdfTextExtractionException(
         'Failed to compute file hash: ${e.message}',
-        e.details?.toString(),
+        _encodeDetails(e.details),
       );
     }
   }
@@ -66,7 +75,7 @@ class AndroidPdfTextExtractor implements PdfTextExtractor {
     } on PlatformException catch (e) {
       throw PdfTextExtractionException(
         'Failed to read text file: ${e.message}',
-        e.details?.toString(),
+        _encodeDetails(e.details),
       );
     }
   }
@@ -79,6 +88,20 @@ class AndroidPdfTextExtractor implements PdfTextExtractor {
     } catch (e) {
       // Fallback sample receipt text
       return [_fallbackSampleText];
+    }
+  }
+
+  String? _encodeDetails(Object? details) {
+    if (details == null) {
+      return null;
+    }
+    if (details is String) {
+      return details;
+    }
+    try {
+      return jsonEncode(details);
+    } catch (_) {
+      return details.toString();
     }
   }
 


### PR DESCRIPTION
## Summary
- expand the Android extractor to decode embedded payloads regardless of file extension, dump attachments for diagnostics, surface stage-level failures, and strengthen OCR with a two-pass pipeline
- instrument the Flutter import service and analytics repository to record PDF extraction stages, refine fallback behaviour, and surface actionable error messaging
- update the import UI with an OCR progress message and retry button, adding the necessary localization strings and Android channel handling for empty-PDF errors

## Testing
- flutter test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f4e395e8832fb374bc135a595994)