### PR TITLE
Improve PDF import handling and error logging

### DIFF
--- a/lib/app/providers.dart
+++ b/lib/app/providers.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import 'package:receipts/core/logging/error_log_service.dart';
 import 'package:receipts/data/repositories/analytics_repository.dart';
 import 'package:receipts/data/repositories/category_repository.dart';
 import 'package:receipts/data/repositories/receipt_repository.dart';
@@ -53,6 +54,7 @@ final importServiceProvider = Provider<ImportService>((ref) {
     parser: ref.read(receiptParserProvider),
     receipts: ref.read(receiptRepositoryProvider),
     analytics: ref.read(analyticsRepositoryProvider),
+    errorLogger: ref.watch(errorLogServiceProvider),
   );
 });
 
@@ -150,4 +152,35 @@ final sentryEnabledProvider =
     StateNotifierProvider<SentryEnabledNotifier, bool>((ref) {
   final repository = ref.watch(settingsRepositoryProvider);
   return SentryEnabledNotifier(repository, false);
+});
+
+class DevLoggingEnabledNotifier extends StateNotifier<bool> {
+  DevLoggingEnabledNotifier(this._repository, bool initialState)
+      : super(initialState);
+
+  final SettingsRepository _repository;
+
+  Future<void> setEnabled(bool value) async {
+    if (state == value) {
+      return;
+    }
+    state = value;
+    await _repository.setDevLoggingEnabled(value);
+  }
+}
+
+final devLoggingEnabledProvider =
+    StateNotifierProvider<DevLoggingEnabledNotifier, bool>((ref) {
+  final repository = ref.watch(settingsRepositoryProvider);
+  return DevLoggingEnabledNotifier(repository, false);
+});
+
+final errorLogServiceProvider = Provider<ErrorLogService>((ref) {
+  final devLoggingEnabled = ref.watch(devLoggingEnabledProvider);
+  return ErrorLogService(enabled: devLoggingEnabled);
+});
+
+final errorLogPathProvider = FutureProvider<String>((ref) async {
+  final logger = ref.watch(errorLogServiceProvider);
+  return logger.logFilePath();
 });

--- a/lib/core/logging/error_log_service.dart
+++ b/lib/core/logging/error_log_service.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+class ErrorLogService {
+  ErrorLogService({required this.enabled});
+
+  final bool enabled;
+
+  static const _logFileName = 'import_errors.log';
+
+  Future<String> logFilePath() async {
+    final file = await _resolveLogFile();
+    return file.path;
+  }
+
+  Future<void> logImportFailure({
+    required String safUri,
+    required String message,
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? details,
+  }) async {
+    if (!enabled) {
+      return;
+    }
+
+    try {
+      final file = await _resolveLogFile();
+      final payload = <String, dynamic>{
+        'timestamp': DateTime.now().toIso8601String(),
+        'source': safUri,
+        'message': message,
+        if (error != null) 'error': error.toString(),
+        if (stackTrace != null) 'stackTrace': stackTrace.toString(),
+        if (details != null && details.isNotEmpty) 'details': details,
+      };
+
+      await file.writeAsString(jsonEncode(payload) + '\n',
+          mode: FileMode.append);
+    } catch (_) {
+      // Ignore logging failures to avoid interfering with the user flow.
+    }
+  }
+
+  Future<File> _resolveLogFile() async {
+    final docsDir = await getApplicationDocumentsDirectory();
+    final logsDir = Directory('${docsDir.path}/receipts_logs');
+
+    if (!await logsDir.exists()) {
+      await logsDir.create(recursive: true);
+    }
+
+    return File('${logsDir.path}/$_logFileName');
+  }
+}

--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -5,10 +5,17 @@ class SettingsRepository {
 
   final SharedPreferences _preferences;
   static const _sentryEnabledKey = 'sentry_enabled';
+  static const _devLoggingEnabledKey = 'dev_logging_enabled';
 
   bool isSentryEnabled() => _preferences.getBool(_sentryEnabledKey) ?? false;
+  bool isDevLoggingEnabled() =>
+      _preferences.getBool(_devLoggingEnabledKey) ?? false;
 
   Future<void> setSentryEnabled(bool value) async {
     await _preferences.setBool(_sentryEnabledKey, value);
+  }
+
+  Future<void> setDevLoggingEnabled(bool value) async {
+    await _preferences.setBool(_devLoggingEnabledKey, value);
   }
 }

--- a/lib/di/test_overrides.dart
+++ b/lib/di/test_overrides.dart
@@ -24,6 +24,9 @@ Future<List<Override>> createIntegrationTestOverrides({
     sentryEnabledProvider.overrideWith((ref) {
       return SentryEnabledNotifier(resolvedSettingsRepository, false);
     }),
+    devLoggingEnabledProvider.overrideWith((ref) {
+      return DevLoggingEnabledNotifier(resolvedSettingsRepository, false);
+    }),
     ...additionalOverrides,
   ];
 }

--- a/lib/features/import/import_service.dart
+++ b/lib/features/import/import_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:developer' as developer;
 
+import 'package:receipts/core/logging/error_log_service.dart';
 import 'package:receipts/data/repositories/analytics_repository.dart';
 import 'package:receipts/data/repositories/receipt_repository.dart';
 import 'package:receipts/domain/models/import_result.dart';
@@ -14,12 +15,14 @@ class ImportService {
     required this.parser,
     required this.receipts,
     required this.analytics,
+    required this.errorLogger,
   });
 
   final PdfTextExtractor pdf;
   final ReceiptParser parser;
   final ReceiptRepository receipts;
   final AnalyticsRepository analytics;
+  final ErrorLogService errorLogger;
 
   Future<ImportResult> importOne(String safUri) async {
     try {
@@ -58,16 +61,25 @@ class ImportService {
         receiptId: savedId,
       );
     } catch (error, stackTrace) {
+      final mappedMessage = _mapImportError(error);
+      final logDetails = _extractLogDetails(error);
       developer.log(
         'Failed to import receipt',
         name: 'ImportService',
         error: error,
         stackTrace: stackTrace,
       );
+      await errorLogger.logImportFailure(
+        safUri: safUri,
+        message: mappedMessage,
+        error: error,
+        stackTrace: stackTrace,
+        details: logDetails,
+      );
       return ImportResult(
         sourceUri: safUri,
         status: ImportStatus.error,
-        message: _mapImportError(error),
+        message: mappedMessage,
       );
     }
   }
@@ -104,7 +116,7 @@ class ImportService {
           outcome: 'normalized_text_empty',
           details: {'message': error.message},
         );
-        return _parseTextFile(safUri);
+        return _parseTextFileOrRethrow(safUri, error);
       }
       rethrow;
     } on PdfTextExtractionException catch (error) {
@@ -114,7 +126,34 @@ class ImportService {
         outcome: 'empty_pdf_text',
         details: stageDetails ?? {'message': error.message},
       );
-      return _parseTextFile(safUri);
+      return _parseTextFileOrRethrow(
+        safUri,
+        error,
+        stageDetails: stageDetails,
+      );
+    }
+  }
+
+  Future<Receipt> _parseTextFileOrRethrow(
+    String safUri,
+    Object extractionError, {
+    Map<String, dynamic>? stageDetails,
+  }) async {
+    try {
+      return await _parseTextFile(safUri);
+    } on FormatException catch (_) {
+      if (extractionError is PdfTextExtractionException) {
+        throw PdfTextExtractionException(
+          extractionError.message,
+          extractionError.details ?? jsonEncode(stageDetails ?? {}),
+        );
+      }
+
+      if (extractionError is FormatException) {
+        throw extractionError;
+      }
+
+      throw FormatException(extractionError.toString());
     }
   }
 
@@ -172,6 +211,18 @@ class ImportService {
       stage: outcome,
       details: details ?? const {},
     );
+  }
+
+  Map<String, dynamic>? _extractLogDetails(Object error) {
+    if (error is PdfTextExtractionException) {
+      return _decodeStageDetails(error.details);
+    }
+
+    if (error is FormatException && _isEmptyPdfFormatError(error)) {
+      return {'stage': 'normalized_text_empty'};
+    }
+
+    return null;
   }
 
   Map<String, dynamic>? _decodeStageDetails(String? raw) {

--- a/lib/features/settings/settings_view.dart
+++ b/lib/features/settings/settings_view.dart
@@ -13,6 +13,8 @@ class SettingsView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sentryEnabled = ref.watch(sentryEnabledProvider);
+    final devLoggingEnabled = ref.watch(devLoggingEnabledProvider);
+    final logPathAsync = ref.watch(errorLogPathProvider);
     final t = AppLocalizations.of(context)!;
     final locale = ref.watch(localeProvider);
 
@@ -180,6 +182,54 @@ class SettingsView extends ConsumerWidget {
           _SettingsSection(
             title: t.debugSectionTitle,
             children: [
+              SwitchListTile(
+                title: Text(
+                  t.enableErrorLogging,
+                  style: AppTextStyles.bodyLarge.copyWith(
+                    color: AppColors.textPrimary,
+                  ),
+                ),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      t.errorLoggingDescription,
+                      style: AppTextStyles.bodyMedium.copyWith(
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    logPathAsync.when(
+                      data: (path) => Text(
+                        t.errorLogPath(path),
+                        style: AppTextStyles.bodySmall.copyWith(
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                      loading: () => const SizedBox.shrink(),
+                      error: (_, __) => const SizedBox.shrink(),
+                    ),
+                  ],
+                ),
+                value: devLoggingEnabled,
+                onChanged: (value) async {
+                  await ref
+                      .read(devLoggingEnabledProvider.notifier)
+                      .setEnabled(value);
+
+                  if (context.mounted && value) {
+                    try {
+                      final path = await ref.read(errorLogPathProvider.future);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(t.errorLogEnabled(path))),
+                      );
+                    } catch (_) {
+                      // Ignore path resolution errors in the dev-only logging toggle.
+                    }
+                  }
+                },
+                contentPadding: EdgeInsets.zero,
+              ),
               ListTile(
                 title: Text(
                   t.clearAllData,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -33,6 +33,20 @@
   "privacyFirstTitle": "Privacy First",
   "privacyFirstDescription": "Your receipts are processed entirely on your device. No data is sent to external servers except for optional crash reports.",
   "debugSectionTitle": "Debug",
+  "enableErrorLogging": "Enable import error logging",
+  "errorLoggingDescription": "Write detailed import errors to a local log file (development only).",
+  "errorLogPath": "Log file: {path}",
+  "@errorLogPath": {
+    "placeholders": {
+      "path": {}
+    }
+  },
+  "errorLogEnabled": "Error logging enabled. File: {path}",
+  "@errorLogEnabled": {
+    "placeholders": {
+      "path": {}
+    }
+  },
   "clearAllData": "Clear all data",
   "clearAllDataDescription": "Remove all receipts and reset the app",
   "clearAllDataDialogTitle": "Clear all data?",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -298,6 +298,30 @@ abstract class AppLocalizations {
   /// **'Debug'**
   String get debugSectionTitle;
 
+  /// No description provided for @enableErrorLogging.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable import error logging'**
+  String get enableErrorLogging;
+
+  /// No description provided for @errorLoggingDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Write detailed import errors to a local log file (development only).'**
+  String get errorLoggingDescription;
+
+  /// No description provided for @errorLogPath.
+  ///
+  /// In en, this message translates to:
+  /// **'Log file: {path}'**
+  String errorLogPath(String path);
+
+  /// No description provided for @errorLogEnabled.
+  ///
+  /// In en, this message translates to:
+  /// **'Error logging enabled. File: {path}'**
+  String errorLogEnabled(String path);
+
   /// No description provided for @clearAllData.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -112,6 +112,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get debugSectionTitle => 'Debug';
 
   @override
+  String get enableErrorLogging => 'Enable import error logging';
+
+  @override
+  String get errorLoggingDescription =>
+      'Write detailed import errors to a local log file (development only).';
+
+  @override
+  String errorLogPath(String path) {
+    return 'Log file: $path';
+  }
+
+  @override
+  String errorLogEnabled(String path) {
+    return 'Error logging enabled. File: $path';
+  }
+
+  @override
   String get clearAllData => 'Clear all data';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -112,6 +112,23 @@ class AppLocalizationsPl extends AppLocalizations {
   String get debugSectionTitle => 'Debugowanie';
 
   @override
+  String get enableErrorLogging => 'Włącz logowanie błędów importu';
+
+  @override
+  String get errorLoggingDescription =>
+      'Zapisuj szczegółowe błędy importu do lokalnego pliku (tylko w wersji deweloperskiej).';
+
+  @override
+  String errorLogPath(String path) {
+    return 'Plik logu: $path';
+  }
+
+  @override
+  String errorLogEnabled(String path) {
+    return 'Logowanie włączone. Plik: $path';
+  }
+
+  @override
   String get clearAllData => 'Wyczyść wszystkie dane';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -113,6 +113,23 @@ class AppLocalizationsRu extends AppLocalizations {
   String get debugSectionTitle => 'Отладка';
 
   @override
+  String get enableErrorLogging => 'Включить логирование ошибок импорта';
+
+  @override
+  String get errorLoggingDescription =>
+      'Записывать подробные ошибки импорта в локальный файл (только для разработки).';
+
+  @override
+  String errorLogPath(String path) {
+    return 'Файл логов: $path';
+  }
+
+  @override
+  String errorLogEnabled(String path) {
+    return 'Логирование включено. Файл: $path';
+  }
+
+  @override
   String get clearAllData => 'Удалить все данные';
 
   @override

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -33,6 +33,20 @@
   "privacyFirstTitle": "Prywatność na pierwszym miejscu",
   "privacyFirstDescription": "Twoje paragony są przetwarzane wyłącznie na Twoim urządzeniu. Żadne dane nie są wysyłane na zewnętrzne serwery, poza opcjonalnymi raportami o awariach.",
   "debugSectionTitle": "Debugowanie",
+  "enableErrorLogging": "Włącz logowanie błędów importu",
+  "errorLoggingDescription": "Zapisuj szczegółowe błędy importu do lokalnego pliku (tylko w wersji deweloperskiej).",
+  "errorLogPath": "Plik logu: {path}",
+  "@errorLogPath": {
+    "placeholders": {
+      "path": {}
+    }
+  },
+  "errorLogEnabled": "Logowanie włączone. Plik: {path}",
+  "@errorLogEnabled": {
+    "placeholders": {
+      "path": {}
+    }
+  },
   "clearAllData": "Wyczyść wszystkie dane",
   "clearAllDataDescription": "Usuń wszystkie paragony i zresetuj aplikację",
   "clearAllDataDialogTitle": "Wyczyścić wszystkie dane?",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -33,6 +33,20 @@
   "privacyFirstTitle": "Приватность прежде всего",
   "privacyFirstDescription": "Ваши чеки обрабатываются полностью на вашем устройстве. Данные не отправляются на внешние серверы, кроме необязательных отчётов об ошибках.",
   "debugSectionTitle": "Отладка",
+  "enableErrorLogging": "Включить логирование ошибок импорта",
+  "errorLoggingDescription": "Записывать подробные ошибки импорта в локальный файл (только для разработки).",
+  "errorLogPath": "Файл логов: {path}",
+  "@errorLogPath": {
+    "placeholders": {
+      "path": {}
+    }
+  },
+  "errorLogEnabled": "Логирование включено. Файл: {path}",
+  "@errorLogEnabled": {
+    "placeholders": {
+      "path": {}
+    }
+  },
   "clearAllData": "Удалить все данные",
   "clearAllDataDescription": "Удалить все чеки и сбросить приложение",
   "clearAllDataDialogTitle": "Удалить все данные?",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,11 +40,18 @@ void main() async {
   final sharedPreferences = await SharedPreferences.getInstance();
   final settingsRepository = SettingsRepository(sharedPreferences);
   final sentryEnabled = settingsRepository.isSentryEnabled();
+  final devLoggingEnabled = settingsRepository.isDevLoggingEnabled();
 
   final baseOverrides = <Override>[
     settingsRepositoryProvider.overrideWithValue(settingsRepository),
     sentryEnabledProvider.overrideWith((ref) {
       return SentryEnabledNotifier(settingsRepository, sentryEnabled);
+    }),
+    devLoggingEnabledProvider.overrideWith((ref) {
+      return DevLoggingEnabledNotifier(
+        settingsRepository,
+        devLoggingEnabled,
+      );
     }),
   ];
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,6 +364,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.17"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   collection: ^1.19.1
   crypto: ^3.0.6
   shared_preferences: ^2.3.2
+  path_provider: ^2.1.5
   cupertino_icons: ^1.0.8
 
 dev_dependencies:

--- a/test/import_pipeline_test.dart
+++ b/test/import_pipeline_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+import 'package:receipts/core/logging/error_log_service.dart';
 import 'package:receipts/data/database.dart';
 import 'package:receipts/data/repositories/analytics_repository.dart';
 import 'package:receipts/data/repositories/receipt_repository.dart';
@@ -39,6 +40,7 @@ void main() {
       parser: ReceiptParser(),
       receipts: receiptRepository,
       analytics: analyticsRepository,
+      errorLogger: ErrorLogService(enabled: false),
     );
 
     final dbPath = await getDatabasesPath();


### PR DESCRIPTION
## Summary
- add a dev-only toggle in settings to capture import errors into a local log file and surface its path
- harden PDF import error handling to avoid falling back to binary text parsing and record richer error details
- persist the new logging flag in shared preferences and propagate it through providers and tests

## Testing
- flutter test test/import_pipeline_test.dart

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc10b9178832fa28ca3b39106884b)