### PR TITLE
Refactor month date range queries

### DIFF
--- a/lib/data/month_date_range.dart
+++ b/lib/data/month_date_range.dart
@@ -1,0 +1,25 @@
+class MonthDateRange {
+  const MonthDateRange({
+    required this.start,
+    required this.end,
+  });
+
+  final DateTime start;
+  final DateTime end;
+
+  int get startMs => start.millisecondsSinceEpoch;
+  int get endMs => end.millisecondsSinceEpoch;
+
+  static MonthDateRange forDate(DateTime date) {
+    final normalized = DateTime(date.year, date.month);
+    return MonthDateRange(
+      start: normalized,
+      end: DateTime(normalized.year, normalized.month + 1),
+    );
+  }
+
+  static MonthDateRange forYearMonth(int year, int month) {
+    final start = DateTime(year, month);
+    return MonthDateRange(start: start, end: DateTime(year, month + 1));
+  }
+}

--- a/lib/data/repositories/analytics_repository.dart
+++ b/lib/data/repositories/analytics_repository.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:receipts/data/database.dart';
+import 'package:receipts/data/month_date_range.dart';
 import 'package:receipts/data/database_update_bus.dart';
 import 'package:receipts/data/database_update_bus_provider.dart';
 import 'package:receipts/domain/category_definitions.dart';
@@ -65,10 +66,10 @@ class AnalyticsRepository {
 
   Future<void> updateAggregatesForMonth(DateTime monthStart) async {
     final db = await DatabaseHelper.database;
-    final normalized = DateTime(monthStart.year, monthStart.month);
-    final month = DateTime(normalized.year, normalized.month);
-    final start = month.millisecondsSinceEpoch;
-    final end = DateTime(month.year, month.month + 1).millisecondsSinceEpoch;
+    final monthRange = MonthDateRange.forDate(monthStart);
+    final month = monthRange.start;
+    final start = monthRange.startMs;
+    final end = monthRange.endMs;
 
     await db.transaction((txn) async {
       final totalResult = await txn.rawQuery(
@@ -137,11 +138,10 @@ class AnalyticsRepository {
 
   Future<MonthOverview> getMonthOverview(DateTime month) async {
     final db = await DatabaseHelper.database;
-    final normalized = DateTime(month.year, month.month);
-    final startOfMonth =
-        DateTime(normalized.year, normalized.month).millisecondsSinceEpoch;
-    final startOfNextMonth =
-        DateTime(normalized.year, normalized.month + 1).millisecondsSinceEpoch;
+    final monthRange = MonthDateRange.forDate(month);
+    final normalized = monthRange.start;
+    final startOfMonth = monthRange.startMs;
+    final startOfNextMonth = monthRange.endMs;
 
     final totalsResult = await db.rawQuery(
       'SELECT COUNT(*) as count, SUM(total_gross) as total FROM receipts WHERE purchase_ts >= ? AND purchase_ts < ?',

--- a/lib/data/repositories/category_repository.dart
+++ b/lib/data/repositories/category_repository.dart
@@ -1,4 +1,5 @@
 import 'package:receipts/data/database.dart';
+import 'package:receipts/data/month_date_range.dart';
 import 'package:receipts/domain/category_definitions.dart';
 import 'package:receipts/domain/models/category.dart';
 import 'package:receipts/domain/models/monthly_total.dart';
@@ -45,14 +46,13 @@ class CategoryRepository {
 
   Future<int> getReceiptCountForMonth(int year, int month) async {
     final db = await DatabaseHelper.database;
-    final startOfMonth = DateTime(year, month).millisecondsSinceEpoch;
-    final startOfNextMonth = DateTime(year, month + 1).millisecondsSinceEpoch;
+    final monthRange = MonthDateRange.forYearMonth(year, month);
 
     final result = await db.query(
       'receipts',
       columns: ['COUNT(*) as count'],
       where: 'purchase_ts >= ? AND purchase_ts < ?',
-      whereArgs: [startOfMonth, startOfNextMonth],
+      whereArgs: [monthRange.startMs, monthRange.endMs],
     );
 
     return result.first['count'] as int;

--- a/lib/data/repositories/receipt_repository.dart
+++ b/lib/data/repositories/receipt_repository.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:receipts/data/database.dart';
+import 'package:receipts/data/month_date_range.dart';
 import 'package:receipts/data/database_update_bus.dart';
 import 'package:receipts/data/database_update_bus_provider.dart';
 import 'package:receipts/domain/models/line_item.dart';
@@ -28,13 +29,12 @@ class ReceiptRepository {
 
   Future<List<Receipt>> getReceiptsByMonth(int year, int month) async {
     final db = await DatabaseHelper.database;
-    final startOfMonth = DateTime(year, month).millisecondsSinceEpoch;
-    final startOfNextMonth = DateTime(year, month + 1).millisecondsSinceEpoch;
+    final monthRange = MonthDateRange.forYearMonth(year, month);
 
     final maps = await db.query(
       'receipts',
       where: 'purchase_ts >= ? AND purchase_ts < ?',
-      whereArgs: [startOfMonth, startOfNextMonth],
+      whereArgs: [monthRange.startMs, monthRange.endMs],
       orderBy: 'purchase_ts DESC',
     );
 
@@ -102,7 +102,7 @@ class ReceiptRepository {
   }
 
   Stream<List<ReceiptRow>> watchReceiptsByMonth(DateTime month) {
-    final normalized = DateTime(month.year, month.month);
+    final normalized = MonthDateRange.forDate(month).start;
     return _watchList(() => _fetchReceiptRowsByMonth(normalized));
   }
 


### PR DESCRIPTION
### Motivation
- Centralize month boundary calculations to remove duplicated `DateTime(year, month + 1)` arithmetic spread across repositories.
- Reduce risk of subtle date-range bugs and improve readability of month-based DB queries.
- Provide a single, testable helper for month range logic to make future changes simpler.

### Description
- Add `MonthDateRange` helper in `lib/data/month_date_range.dart` with `forDate` and `forYearMonth` constructors and `startMs`/`endMs` getters.
- Update `AnalyticsRepository` to use `MonthDateRange` for `updateAggregatesForMonth` and `getMonthOverview` to compute month boundaries.
- Update `CategoryRepository` to use `MonthDateRange.forYearMonth` in `getReceiptCountForMonth`.
- Update `ReceiptRepository` to use `MonthDateRange` in `getReceiptsByMonth` and `watchReceiptsByMonth` and adjust imports accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696562d256c0832fa0427293d9c7d7a9)