### PR TITLE
Fix integration test import status checks

### DIFF
--- a/integration_test/app_flow_test.dart
+++ b/integration_test/app_flow_test.dart
@@ -123,7 +123,7 @@ void main() {
     await tester.tap(find.byKey(TestKeys.importButton));
     await pumpAndSettleSafe(tester, timeout: const Duration(seconds: 20));
 
-    expect(find.textContaining('Success'), findsWidgets);
+    expect(find.byKey(TestKeys.importStatusSuccess), findsWidgets);
 
     await tester.tap(find.byKey(TestKeys.navReceipts));
     await pumpAndSettleSafe(tester, timeout: const Duration(seconds: 10));
@@ -159,6 +159,6 @@ void main() {
     await tester.tap(find.byKey(TestKeys.importButton));
     await pumpAndSettleSafe(tester);
 
-    expect(find.textContaining('Error'), findsWidgets);
+    expect(find.byKey(TestKeys.importStatusError), findsWidgets);
   });
 }

--- a/integration_test/test_keys.dart
+++ b/integration_test/test_keys.dart
@@ -7,6 +7,8 @@ class TestKeys {
   static const navReceipts = ValueKey('nav_receipts');
   static const navSettings = ValueKey('nav_settings');
   static const importButton = ValueKey('import_button');
+  static const importStatusSuccess = ValueKey('import_status_success');
+  static const importStatusError = ValueKey('import_status_error');
   static const receiptList = ValueKey('receipt_list');
   static const chartView = ValueKey('chart_view');
   static const onboardingGetStarted = ValueKey('onboarding_get_started');

--- a/lib/features/import/import_view.dart
+++ b/lib/features/import/import_view.dart
@@ -202,6 +202,7 @@ class _ImportHistoryItem extends StatelessWidget {
     final fileName = _resolveFileName(t, result.sourceUri);
     final subtitle = _buildSubtitle(t, entry.timestamp, result.message);
     final badgeStyle = _badgeStyle(result.status, t);
+    final badgeKey = _statusBadgeKey(result.status);
     final retryButton = result.status == ImportStatus.error
         ? TextButton(
             onPressed: () => onRetry(result.sourceUri),
@@ -230,6 +231,7 @@ class _ImportHistoryItem extends StatelessWidget {
           ],
         ),
         trailing: _StatusBadge(
+          key: badgeKey,
           label: badgeStyle.label,
           color: badgeStyle.color,
           outlined: badgeStyle.outlined,
@@ -300,10 +302,22 @@ class _ImportHistoryItem extends StatelessWidget {
       return t.daysAgo(days);
     }
   }
+
+  Key _statusBadgeKey(ImportStatus status) {
+    switch (status) {
+      case ImportStatus.success:
+        return const ValueKey('import_status_success');
+      case ImportStatus.duplicate:
+        return const ValueKey('import_status_duplicate');
+      case ImportStatus.error:
+        return const ValueKey('import_status_error');
+    }
+  }
 }
 
 class _StatusBadge extends StatelessWidget {
   const _StatusBadge({
+    super.key,
     required this.label,
     required this.color,
     this.outlined = false,


### PR DESCRIPTION
### Motivation
- Integration tests were asserting UI text labels (`"Success"`/`"Error"`) which depend on localization and caused flaky failures in CI.
- Make the import status UI targetable by tests using stable identifiers instead of localized strings.

### Description
- Add explicit `ValueKey`s for import status badges in `lib/features/import/import_view.dart` so each `ImportStatus` maps to a stable key (`import_status_success`, `import_status_duplicate`, `import_status_error`).
- Expose the badge `key` via `_statusBadgeKey` and wire it into the `_StatusBadge` widget.
- Update integration test helpers in `integration_test/test_keys.dart` to include `importStatusSuccess` and `importStatusError` keys.
- Replace text-based assertions in `integration_test/app_flow_test.dart` with key-based assertions using `TestKeys.importStatusSuccess` and `TestKeys.importStatusError`.

### Testing
- No automated tests were executed as part of this change (no CI run requested).
- The change is limited to adding widget keys and updating integration tests to use them, so it should make the existing integration tests more robust when run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69657e19236c832f8862d9100ca4e7ff)