### PR TITLE
Fix integration test key on month stats view

### DIFF
--- a/lib/features/month/month_view.dart
+++ b/lib/features/month/month_view.dart
@@ -64,7 +64,10 @@ class MonthView extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: AppSpacing.md),
-            _CategoryBreakdown(overview: monthOverviewAsync),
+            _CategoryBreakdown(
+              key: const ValueKey('chart_view'),
+              overview: monthOverviewAsync,
+            ),
             const SizedBox(height: AppSpacing.lg),
             Row(
               children: [
@@ -249,7 +252,7 @@ class _MonthPicker extends ConsumerWidget {
 }
 
 class _CategoryBreakdown extends StatelessWidget {
-  const _CategoryBreakdown({required this.overview});
+  const _CategoryBreakdown({super.key, required this.overview});
 
   final AsyncValue<MonthOverview> overview;
 


### PR DESCRIPTION
### Motivation

- The integration test expects a widget with the `chart_view` key when navigating to the stats view, but the month stats page did not expose that key, causing the integration flow to miss the expected target. 

### Description

- Added the `chart_view` `ValueKey` to the month category breakdown instance in `lib/features/month/month_view.dart` so the stats navigation target is present. 
- Updated the `_CategoryBreakdown` constructor to accept a `key` by forwarding `super.key` so the widget can be targeted by tests.

### Testing

- Ran `flutter test integration_test`, which failed to run due to the local Flutter SDK reporting `0.0.0-unknown` and not satisfying the required `>=3.24.0` constraint, so integration tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696660bb50832f8b6d56df156cdd9b)