### PR TITLE
Fix localization placeholder types for error log path

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,13 +38,17 @@
   "errorLogPath": "Log file: {path}",
   "@errorLogPath": {
     "placeholders": {
-      "path": {}
+      "path": {
+        "type": "Object"
+      }
     }
   },
   "errorLogEnabled": "Error logging enabled. File: {path}",
   "@errorLogEnabled": {
     "placeholders": {
-      "path": {}
+      "path": {
+        "type": "Object"
+      }
     }
   },
   "clearAllData": "Clear all data",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -38,13 +38,17 @@
   "errorLogPath": "Plik logu: {path}",
   "@errorLogPath": {
     "placeholders": {
-      "path": {}
+      "path": {
+        "type": "Object"
+      }
     }
   },
   "errorLogEnabled": "Logowanie włączone. Plik: {path}",
   "@errorLogEnabled": {
     "placeholders": {
-      "path": {}
+      "path": {
+        "type": "Object"
+      }
     }
   },
   "clearAllData": "Wyczyść wszystkie dane",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -38,13 +38,17 @@
   "errorLogPath": "Файл логов: {path}",
   "@errorLogPath": {
     "placeholders": {
-      "path": {}
+      "path": {
+        "type": "Object"
+      }
     }
   },
   "errorLogEnabled": "Логирование включено. Файл: {path}",
   "@errorLogEnabled": {
     "placeholders": {
-      "path": {}
+      "path": {
+        "type": "Object"
+      }
     }
   },
   "clearAllData": "Удалить все данные",


### PR DESCRIPTION
### Motivation
- Fix a gen-l10n failure caused by a mismatch in the `path` placeholder type (was missing/null in some locales while the template expects `Object`).

### Description
- Add explicit `"type": "Object"` for the `path` placeholder in `@errorLogPath` and `@errorLogEnabled` entries in `lib/l10n/app_en.arb`, `lib/l10n/app_pl.arb`, and `lib/l10n/app_ru.arb` to align locale metadata with the template.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c1acc635c832f979b54788b85ec3e)